### PR TITLE
ID167 社長音声DBの登録元と日時表示を整える

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -109,6 +109,8 @@ class CeoTranscription(Base):
     source_file_size_bytes = Column(Integer, nullable=True)
     source_file_modified_at = Column(String(64), nullable=True)
     source_file_hash = Column(String(64), nullable=True)
+    source_app = Column(String(32), nullable=False, default="unknown", server_default=text("'unknown'"))
+    input_method = Column(String(32), nullable=False, default="unknown", server_default=text("'unknown'"))
     title = Column(String(500), nullable=True)
     speaker = Column(String(200), nullable=True)
     recorded_at = Column(String(64), nullable=True)
@@ -300,6 +302,8 @@ _ensure_columns(
         "source_file_size_bytes": "INTEGER",
         "source_file_modified_at": "TEXT",
         "source_file_hash": "TEXT",
+        "source_app": "TEXT NOT NULL DEFAULT 'unknown'",
+        "input_method": "TEXT NOT NULL DEFAULT 'unknown'",
         "title": "TEXT",
         "speaker": "TEXT",
         "recorded_at": "TEXT",

--- a/src/services/ceo_processor.py
+++ b/src/services/ceo_processor.py
@@ -495,6 +495,8 @@ def process_ceo_uploaded_path(
                 source_file_size_bytes=source_file_size_bytes,
                 source_file_modified_at=source_file_modified_at,
                 source_file_hash=source_file_hash,
+                source_app="web",
+                input_method="mic",
                 title=title,
                 speaker=speaker,
                 recorded_at=recorded_at,

--- a/src/services/ceo_time_utils.py
+++ b/src/services/ceo_time_utils.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time
+from typing import Any
+
+
+def timestamp_seconds(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.timestamp()
+    if isinstance(value, date):
+        return datetime.combine(value, time.min).timestamp()
+
+    raw = str(value).strip()
+    if not raw:
+        return None
+
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def ceo_record_sort_key(record: Any) -> tuple[bool, float, int]:
+    timestamp = timestamp_seconds(getattr(record, "recorded_at", None))
+    if timestamp is None:
+        timestamp = timestamp_seconds(getattr(record, "created_at", None))
+    return (timestamp is None, -(timestamp or 0), -(getattr(record, "id", 0) or 0))

--- a/src/services/ceo_time_utils.py
+++ b/src/services/ceo_time_utils.py
@@ -1,25 +1,36 @@
 from __future__ import annotations
 
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timedelta, timezone
 from typing import Any
 
+JST = timezone(timedelta(hours=9))
 
-def timestamp_seconds(value: Any) -> float | None:
+
+def parse_timestamp(value: Any) -> datetime | None:
     if value is None:
         return None
     if isinstance(value, datetime):
-        return value.timestamp()
+        return value
     if isinstance(value, date):
-        return datetime.combine(value, time.min).timestamp()
+        return datetime.combine(value, time.min)
 
     raw = str(value).strip()
     if not raw:
         return None
 
     try:
-        return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
     except ValueError:
         return None
+
+
+def timestamp_seconds(value: Any) -> float | None:
+    parsed = parse_timestamp(value)
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        parsed = parsed.replace(tzinfo=JST)
+    return parsed.timestamp()
 
 
 def ceo_record_sort_key(record: Any) -> tuple[bool, float, int]:
@@ -27,3 +38,35 @@ def ceo_record_sort_key(record: Any) -> tuple[bool, float, int]:
     if timestamp is None:
         timestamp = timestamp_seconds(getattr(record, "created_at", None))
     return (timestamp is None, -(timestamp or 0), -(getattr(record, "id", 0) or 0))
+
+
+def _aware_as_jst_naive(value: Any) -> tuple[str, datetime | None]:
+    if value is None:
+        return "-", None
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return "-", None
+    else:
+        raw = str(value)
+
+    parsed = parse_timestamp(value)
+    if parsed is None:
+        return raw, None
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        return raw, None
+    return raw, parsed.astimezone(JST).replace(tzinfo=None)
+
+
+def format_recorded_at_for_web(value: Any) -> str:
+    raw, converted = _aware_as_jst_naive(value)
+    if converted is None:
+        return raw
+    return converted.strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def format_created_at_for_web(value: Any) -> str:
+    raw, converted = _aware_as_jst_naive(value)
+    if converted is None:
+        return raw
+    return str(converted)

--- a/src/services/ceo_time_utils.py
+++ b/src/services/ceo_time_utils.py
@@ -67,6 +67,10 @@ def format_recorded_at_for_web(value: Any) -> str:
 
 def format_created_at_for_web(value: Any) -> str:
     raw, converted = _aware_as_jst_naive(value)
-    if converted is None:
+    if converted is not None:
+        return converted.strftime("%Y-%m-%d %H:%M:%S")
+
+    parsed = parse_timestamp(value)
+    if parsed is None:
         return raw
-    return str(converted)
+    return parsed.replace(tzinfo=None).strftime("%Y-%m-%d %H:%M:%S")

--- a/src/ui/tabs/ceo_db_tab.py
+++ b/src/ui/tabs/ceo_db_tab.py
@@ -11,7 +11,11 @@ import streamlit as st
 from sqlalchemy import delete
 
 from models import CeoTranscription, get_db
-from services.ceo_time_utils import ceo_record_sort_key
+from services.ceo_time_utils import (
+    ceo_record_sort_key,
+    format_created_at_for_web,
+    format_recorded_at_for_web,
+)
 
 
 SOURCE_APP_LABELS = {
@@ -58,6 +62,8 @@ def _load_records():
         input_method = record.input_method or "unknown"
         source_app_label = _label(source_app, SOURCE_APP_LABELS)
         input_method_label = _label(input_method, INPUT_METHOD_LABELS)
+        recorded_at_display = format_recorded_at_for_web(record.recorded_at)
+        created_at_display = format_created_at_for_web(record.created_at)
         table_rows.append(
             {
                 "ID": record.id,
@@ -65,8 +71,8 @@ def _load_records():
                 "話者": record.speaker or "-",
                 "登録元": source_app_label,
                 "取り込み方法": input_method_label,
-                "録音日時": record.recorded_at or "-",
-                "登録日時": record.created_at,
+                "録音日時": recorded_at_display,
+                "登録日時": created_at_display,
                 "長さ(s)": record.duration_seconds,
                 "ファイル": record.source_file_path or record.file_path or "-",
                 "文字起こし": transcript[:50] + ("…" if len(transcript) > 50 else ""),
@@ -78,8 +84,8 @@ def _load_records():
                 "id": record.id,
                 "title": record.title,
                 "speaker": record.speaker,
-                "recorded_at": record.recorded_at,
-                "created_at": record.created_at,
+                "recorded_at": recorded_at_display,
+                "created_at": created_at_display,
                 "duration_seconds": record.duration_seconds,
                 "source_file_path": record.source_file_path,
                 "source_file_size_bytes": record.source_file_size_bytes,

--- a/src/ui/tabs/ceo_db_tab.py
+++ b/src/ui/tabs/ceo_db_tab.py
@@ -13,6 +13,24 @@ from sqlalchemy import delete
 from models import CeoTranscription, get_db
 
 
+SOURCE_APP_LABELS = {
+    "web": "Web版",
+    "desktop": "アプリ版",
+    "unknown": "未判定",
+}
+
+INPUT_METHOD_LABELS = {
+    "mic": "マイク録音",
+    "file_import": "ファイル取り込み",
+    "unknown": "未判定",
+}
+
+
+def _label(value, labels: dict[str, str]) -> str:
+    raw = str(value or "unknown").strip() or "unknown"
+    return labels.get(raw, raw)
+
+
 def _ensure_state() -> None:
     st.session_state.setdefault(
         "ceo_db_tab_state",
@@ -39,11 +57,17 @@ def _load_records():
     detail_rows: list[dict] = []
     for record in records:
         transcript = record.transcript or ""
+        source_app = record.source_app or "unknown"
+        input_method = record.input_method or "unknown"
+        source_app_label = _label(source_app, SOURCE_APP_LABELS)
+        input_method_label = _label(input_method, INPUT_METHOD_LABELS)
         table_rows.append(
             {
                 "ID": record.id,
                 "タイトル": record.title or "-",
                 "話者": record.speaker or "-",
+                "登録元": source_app_label,
+                "取り込み方法": input_method_label,
                 "録音日時": record.recorded_at or "-",
                 "登録日時": record.created_at,
                 "長さ(s)": record.duration_seconds,
@@ -64,6 +88,10 @@ def _load_records():
                 "source_file_size_bytes": record.source_file_size_bytes,
                 "source_file_modified_at": record.source_file_modified_at,
                 "source_file_hash": record.source_file_hash,
+                "source_app": source_app,
+                "source_app_label": source_app_label,
+                "input_method": input_method,
+                "input_method_label": input_method_label,
                 "file_path": record.file_path,
                 "local_file_path": record.local_file_path,
                 "model_id": record.model_id,
@@ -141,6 +169,8 @@ def run_ceo_db_tab() -> None:
         q = text_filter.strip().lower()
         mask = (
             filtered["タイトル"].astype(str).str.lower().str.contains(q, regex=False, na=False)
+            | filtered["登録元"].astype(str).str.lower().str.contains(q, regex=False, na=False)
+            | filtered["取り込み方法"].astype(str).str.lower().str.contains(q, regex=False, na=False)
             | filtered["_文字起こし全文"].astype(str).str.lower().str.contains(q, regex=False, na=False)
             | filtered["ファイル"].astype(str).str.lower().str.contains(q, regex=False, na=False)
         )
@@ -168,6 +198,8 @@ def run_ceo_db_tab() -> None:
         with meta_l:
             st.write(f"**タイトル:** {record['title'] or '-'}")
             st.write(f"**話者:** {record['speaker'] or '-'}")
+            st.write(f"**登録元:** {record['source_app_label']}")
+            st.write(f"**取り込み方法:** {record['input_method_label']}")
             st.write(f"**録音日時:** {record['recorded_at'] or '-'}")
             st.write(f"**登録日時:** {record['created_at']}")
             st.write(f"**長さ:** {record['duration_seconds']}")

--- a/src/ui/tabs/ceo_db_tab.py
+++ b/src/ui/tabs/ceo_db_tab.py
@@ -11,6 +11,7 @@ import streamlit as st
 from sqlalchemy import delete
 
 from models import CeoTranscription, get_db
+from services.ceo_time_utils import ceo_record_sort_key
 
 
 SOURCE_APP_LABELS = {
@@ -45,11 +46,7 @@ def _ensure_state() -> None:
 def _load_records():
     db = next(get_db())
     try:
-        records = (
-            db.query(CeoTranscription)
-            .order_by(CeoTranscription.recorded_at.desc(), CeoTranscription.created_at.desc())
-            .all()
-        )
+        records = sorted(db.query(CeoTranscription).all(), key=ceo_record_sort_key)
     finally:
         db.close()
 

--- a/tests/test_ceo_db_sort.py
+++ b/tests/test_ceo_db_sort.py
@@ -1,30 +1,42 @@
 import os
 import sys
 import time
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 import pytest  # noqa: E402
-from services.ceo_time_utils import ceo_record_sort_key  # noqa: E402
+from services.ceo_time_utils import (  # noqa: E402
+    ceo_record_sort_key,
+    format_created_at_for_web,
+    format_recorded_at_for_web,
+)
+
+
+@contextmanager
+def process_timezone(name: str):
+    old_tz = os.environ.get("TZ")
+    os.environ["TZ"] = name
+    if hasattr(time, "tzset"):
+        time.tzset()
+
+    try:
+        yield
+    finally:
+        if old_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = old_tz
+        if hasattr(time, "tzset"):
+            time.tzset()
 
 
 @pytest.fixture
 def jst_timezone():
-    old_tz = os.environ.get("TZ")
-    os.environ["TZ"] = "Asia/Tokyo"
-    if hasattr(time, "tzset"):
-        time.tzset()
-
-    yield
-
-    if old_tz is None:
-        os.environ.pop("TZ", None)
-    else:
-        os.environ["TZ"] = old_tz
-    if hasattr(time, "tzset"):
-        time.tzset()
+    with process_timezone("Asia/Tokyo"):
+        yield
 
 
 def test_record_sort_key_orders_mixed_timestamp_formats_by_display_time(jst_timezone):
@@ -55,3 +67,34 @@ def test_record_sort_key_falls_back_to_created_at_and_id(jst_timezone):
     sorted_ids = [row.id for row in sorted(rows, key=ceo_record_sort_key)]
 
     assert sorted_ids == [2, 3, 1, 4]
+
+
+def test_web_recorded_at_display_uses_main_recording_format(jst_timezone):
+    assert format_recorded_at_for_web("2026-07-07T11:02:28") == "2026-07-07T11:02:28"
+    assert format_recorded_at_for_web("2026-07-07T02:02:00.000Z") == "2026-07-07T11:02:00"
+    assert format_recorded_at_for_web("2026-07-07T11:02:00+09:00") == "2026-07-07T11:02:00"
+
+
+def test_web_created_at_display_keeps_main_web_values_and_localizes_aware_values(jst_timezone):
+    assert (
+        format_created_at_for_web("2026-07-07 11:02:30.572861")
+        == "2026-07-07 11:02:30.572861"
+    )
+    assert (
+        format_created_at_for_web("2026-07-07T02:03:13.856666+00:00")
+        == "2026-07-07 11:03:13.856666"
+    )
+    assert format_created_at_for_web("2026-07-07T02:03:13+00:00") == "2026-07-07 11:03:13"
+
+
+def test_record_sort_key_does_not_depend_on_process_timezone():
+    with process_timezone("UTC"):
+        rows = [
+            SimpleNamespace(id=8, recorded_at="2026-07-06T09:11:00.000Z", created_at=None),
+            SimpleNamespace(id=7, recorded_at="2026-07-06T18:10:51", created_at=None),
+        ]
+
+        sorted_ids = [row.id for row in sorted(rows, key=ceo_record_sort_key)]
+
+        assert sorted_ids == [8, 7]
+        assert format_recorded_at_for_web("2026-07-06T09:11:00.000Z") == "2026-07-06T18:11:00"

--- a/tests/test_ceo_db_sort.py
+++ b/tests/test_ceo_db_sort.py
@@ -2,6 +2,7 @@ import os
 import sys
 import time
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -75,16 +76,26 @@ def test_web_recorded_at_display_uses_main_recording_format(jst_timezone):
     assert format_recorded_at_for_web("2026-07-07T11:02:00+09:00") == "2026-07-07T11:02:00"
 
 
-def test_web_created_at_display_keeps_main_web_values_and_localizes_aware_values(jst_timezone):
+def test_web_created_at_display_uses_seconds_and_localizes_aware_values(jst_timezone):
     assert (
         format_created_at_for_web("2026-07-07 11:02:30.572861")
-        == "2026-07-07 11:02:30.572861"
+        == "2026-07-07 11:02:30"
     )
     assert (
         format_created_at_for_web("2026-07-07T02:03:13.856666+00:00")
-        == "2026-07-07 11:03:13.856666"
+        == "2026-07-07 11:03:13"
     )
     assert format_created_at_for_web("2026-07-07T02:03:13+00:00") == "2026-07-07 11:03:13"
+    assert (
+        format_created_at_for_web(datetime(2026, 7, 7, 11, 37, 58, 310708))
+        == "2026-07-07 11:37:58"
+    )
+    assert (
+        format_created_at_for_web(
+            datetime(2026, 7, 7, 2, 37, 58, 310708, tzinfo=timezone.utc)
+        )
+        == "2026-07-07 11:37:58"
+    )
 
 
 def test_record_sort_key_does_not_depend_on_process_timezone():

--- a/tests/test_ceo_db_sort.py
+++ b/tests/test_ceo_db_sort.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pytest  # noqa: E402
+from services.ceo_time_utils import ceo_record_sort_key  # noqa: E402
+
+
+@pytest.fixture
+def jst_timezone():
+    old_tz = os.environ.get("TZ")
+    os.environ["TZ"] = "Asia/Tokyo"
+    if hasattr(time, "tzset"):
+        time.tzset()
+
+    yield
+
+    if old_tz is None:
+        os.environ.pop("TZ", None)
+    else:
+        os.environ["TZ"] = old_tz
+    if hasattr(time, "tzset"):
+        time.tzset()
+
+
+def test_record_sort_key_orders_mixed_timestamp_formats_by_display_time(jst_timezone):
+    rows = [
+        SimpleNamespace(id=7, recorded_at="2026-07-06T18:10:51", created_at=None),
+        SimpleNamespace(id=6, recorded_at="2026-07-06T18:09:31", created_at=None),
+        SimpleNamespace(id=5, recorded_at="2026-07-06T17:46:37", created_at=None),
+        SimpleNamespace(id=2, recorded_at="2026-07-06T11:20:00+09:00", created_at=None),
+        SimpleNamespace(id=8, recorded_at="2026-07-06T09:11:00.000Z", created_at=None),
+        SimpleNamespace(id=1, recorded_at="2026-07-06T09:00:00+09:00", created_at=None),
+        SimpleNamespace(id=4, recorded_at="2026-07-06T07:48:00.000Z", created_at=None),
+        SimpleNamespace(id=3, recorded_at="2026-07-05T17:40:00+09:00", created_at=None),
+    ]
+
+    sorted_ids = [row.id for row in sorted(rows, key=ceo_record_sort_key)]
+
+    assert sorted_ids == [8, 7, 6, 5, 4, 2, 1, 3]
+
+
+def test_record_sort_key_falls_back_to_created_at_and_id(jst_timezone):
+    rows = [
+        SimpleNamespace(id=1, recorded_at="", created_at="2026-07-06 12:00:00.000000"),
+        SimpleNamespace(id=3, recorded_at=None, created_at="2026-07-06 12:00:00.000000"),
+        SimpleNamespace(id=2, recorded_at="not-a-date", created_at="2026-07-06 13:00:00.000000"),
+        SimpleNamespace(id=4, recorded_at="not-a-date", created_at=None),
+    ]
+
+    sorted_ids = [row.id for row in sorted(rows, key=ceo_record_sort_key)]
+
+    assert sorted_ids == [2, 3, 1, 4]


### PR DESCRIPTION
## 概要
- 社長音声DBの保存データに登録元・取り込み方法の情報を追加しました。
- 一覧表示と詳細表示で登録元・取り込み方法を確認できるようにしました。
- 録音日時・登録日時の解釈とソート処理を共通ユーティリティ化しました。
- 登録日時の画面表示を `2026-07-07 11:37:58` のように秒単位へ統一し、microseconds が表示されないようにしました。

## 背景・原因
- main では `recorded_at` と `created_at` を画面用に整形せず、そのまま表示していました。
- `recorded_at` は文字列保存、`created_at` は登録時刻として生成されるため、保存元によって `T` 区切り・タイムゾーン付き・microseconds 付きの表示揺れが起き得ました。

## 影響範囲
- Web版の社長音声DBタブの一覧表示・詳細表示・保存時メタデータ。
- 既存データは登録元・取り込み方法が未設定の場合でもフォールバック表示します。
- DB保存値は変えず、画面表示とソート時の解釈を整えます。

## 検証
- `uv run --isolated --with pytest python -m pytest`
- `git diff --check origin/main...HEAD`
