### PR TITLE
AIモデルと文字起こしモデルを更新

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,13 +5,17 @@ OPENAI_API_KEY=your-openai-api-key
 ELEVENLABS_API_KEY=your-elevenlabs-api-key
 # 既定の言語コード（未指定時に適用）。例: ja / en / zh など
 ELEVENLABS_LANGUAGE_CODE=ja
-# 使用するSTTモデルID（例: scribe_v1 / scribe_v1_experimental）
-ELEVENLABS_MODEL_ID=scribe_v1
+# 使用するSTTモデルID
+ELEVENLABS_MODEL_ID=scribe_v2
 # 非音声イベントのタグ付け（laughter, applause など）を含めるか
 ELEVENLABS_TAG_AUDIO_EVENTS=false
 
 # Google Generative AI (Gemini)
 GEMINI_API_KEY=your-gemini-api-key
+
+# Google Cloud Speech-to-Text
+GOOGLE_CLOUD_PROJECT=your-google-cloud-project-id
+GOOGLE_CLOUD_LOCATION=us
 
 # Database
 DATABASE_URL=sqlite:///./audio_transcriptions.db
@@ -28,7 +32,7 @@ DATABASE_URL=sqlite:///./audio_transcriptions.db
 # ENABLE_RAG=true
 # EMBEDDING_MODEL=text-embedding-3-small   # 低コスト・日本語も良好、1536次元
 # EMBEDDING_DIM=1536                        # 上のモデルに合わせる（変更時はDB再作成が必要）
-# RAG_COMPLETION_MODEL=gpt-5-mini          # Responses API対応の推奨既定（2025-10）
+# RAG_COMPLETION_MODEL=gpt-5.6-luna        # Responses API対応の推奨既定
 # RAG_CONTEXT_MAX_CHUNKS=12       # 回答プロンプトに入れる最大チャンク数
 # RAG_CONTEXT_MAX_CHARS=20000      # 回答プロンプトに入れる総文字数上限（安全策）
 # RAG_RETRIEVAL_K=100              # 検索候補として取得する上位件数（UI非表示、全データから選出）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,7 @@ uv lock --upgrade
 - 本リポジトリはデータベースをTurso(libSQL)に完全移行済み。Postgres/pgvector対応はコードから削除済みです。関連依存（psycopg2, pgvector）も`pyproject.toml`から除外しました。
 - DB関連の実装・最適化はlibSQLのベクトル関数（`vector_top_k`, `vector_distance_cos`, `libsql_vector_idx`）とFTS5のみを前提にしてください。
 - QA検索タブの回答生成は「ストリーミングのみ」です。非ストリーミングAPIはコードから撤去済みです。
-- 既定のRAGモデル: `EMBEDDING_MODEL=text-embedding-3-small (1536次元)`, `RAG_COMPLETION_MODEL=gpt-5-mini`。Responses APIを使用。
+- 既定のRAGモデル: `EMBEDDING_MODEL=text-embedding-3-small (1536次元)`, `RAG_COMPLETION_MODEL=gpt-5.6-luna`。Responses APIを使用。
 - `EMBEDDING_DIM` を変更する場合はDB列定義が固定のため、再作成（既存チャンク削除→再インデックス）が必要。
 - プロンプトは番号付きコンテキスト＋出典必須（[#番号]）で構成。回答/根拠/不足情報の3セクション出力を期待。
 - 温度は既定値（未指定）。再現性が要る場合は `.env` で上書きではなくプロンプト・候補件数を調整する。

--- a/scripts/transcribe_all.py
+++ b/scripts/transcribe_all.py
@@ -52,7 +52,7 @@ def run_openai_transcription(audio_files):
         from transcribe_openai import transcribe_audio_file
         results = {}
         
-        print("\n=== OpenAI gpt-4o-transcribe ===")
+        print("\n=== OpenAI gpt-transcribe ===")
         for i, audio_file in enumerate(audio_files, 1):
             print(f"[{i}/{len(audio_files)}] {audio_file.name}")
             transcription = transcribe_audio_file(audio_file)
@@ -72,10 +72,10 @@ def run_google_transcription(audio_files):
         from transcribe_google import transcribe_audio_file
         results = {}
         
-        print("\n=== Google Cloud Speech-to-Text (Chirp) ===")
+        print("\n=== Google Cloud Speech-to-Text (Chirp 3) ===")
         for i, audio_file in enumerate(audio_files, 1):
             print(f"[{i}/{len(audio_files)}] {audio_file.name}")
-            transcription = transcribe_audio_file(audio_file, model="chirp")
+            transcription = transcribe_audio_file(audio_file, model="chirp_3")
             if transcription:
                 results[audio_file.name] = transcription
             else:

--- a/scripts/transcribe_elevenlabs.py
+++ b/scripts/transcribe_elevenlabs.py
@@ -34,7 +34,7 @@ logger.addHandler(file_handler)
 
 # ElevenLabs設定（環境変数で挙動を制御可能）
 ELEVENLABS_API_KEY = os.getenv("ELEVENLABS_API_KEY")
-ELEVENLABS_MODEL_ID = os.getenv("ELEVENLABS_MODEL_ID", "scribe_v1")
+ELEVENLABS_MODEL_ID = os.getenv("ELEVENLABS_MODEL_ID", "scribe_v2")
 # 既定は日本語に固定（UI 経由の呼び出しは従来言語未指定で自動判定だった）
 ELEVENLABS_DEFAULT_LANG = os.getenv("ELEVENLABS_LANGUAGE_CODE", "ja")
 ELEVENLABS_TAG_EVENTS = os.getenv("ELEVENLABS_TAG_AUDIO_EVENTS", "false").lower() in ("1", "true", "yes", "on")
@@ -94,12 +94,12 @@ def transcribe_audio_file(audio_file_path, language_code=None):
         with open(audio_file_path, "rb") as audio_file:
             logger.debug("音声ファイルを読み込み中...")
             # Speech-to-Text変換を実行
-            # Scribe v1モデルを使用
+            # Scribeモデルを使用
             logger.debug("API呼び出し開始...")
             # APIパラメータを構築
             api_params = {
                 "file": audio_file,
-                "model_id": ELEVENLABS_MODEL_ID,  # 既定は "scribe_v1"（env で上書き可）
+                "model_id": ELEVENLABS_MODEL_ID,  # 既定は "scribe_v2"（env で上書き可）
                 "tag_audio_events": ELEVENLABS_TAG_EVENTS,
             }
             

--- a/scripts/transcribe_google.py
+++ b/scripts/transcribe_google.py
@@ -8,16 +8,17 @@ from google.cloud.speech_v2.types import cloud_speech
 
 # Google Cloud プロジェクトID
 PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+LOCATION = os.getenv("GOOGLE_CLOUD_LOCATION", "us")
 if not PROJECT_ID:
     print("警告: GOOGLE_CLOUD_PROJECT環境変数が設定されていません。")
     PROJECT_ID = "your-project-id"  # ここにプロジェクトIDを設定
 
-def transcribe_audio_file(audio_file_path, model="chirp", language_code="ja-JP"):
-    """Google Cloud Speech-to-Text (Chirp/Chirp2)で音声ファイルを文字起こしする
+def transcribe_audio_file(audio_file_path, model="chirp_3", language_code="ja-JP"):
+    """Google Cloud Speech-to-Text (Chirp)で音声ファイルを文字起こしする
     
     Args:
         audio_file_path: 音声ファイルのパス
-        model: 使用するモデル ("chirp" または "chirp_2")
+        model: 使用するモデル ("chirp", "chirp_2", "chirp_3")
         language_code: 言語コード (例: "ja-JP", "en-US")
     
     Returns:
@@ -27,7 +28,7 @@ def transcribe_audio_file(audio_file_path, model="chirp", language_code="ja-JP")
         # クライアントの初期化
         client = SpeechClient(
             client_options=ClientOptions(
-                api_endpoint="us-central1-speech.googleapis.com",
+                api_endpoint=f"{LOCATION}-speech.googleapis.com",
             )
         )
         
@@ -39,12 +40,12 @@ def transcribe_audio_file(audio_file_path, model="chirp", language_code="ja-JP")
         config = cloud_speech.RecognitionConfig(
             auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
             language_codes=[language_code],
-            model=model,  # "chirp" または "chirp_2"
+            model=model,
         )
         
         # リクエストの作成
         request = cloud_speech.RecognizeRequest(
-            recognizer=f"projects/{PROJECT_ID}/locations/us-central1/recognizers/_",
+            recognizer=f"projects/{PROJECT_ID}/locations/{LOCATION}/recognizers/_",
             config=config,
             content=audio_content,
         )
@@ -77,7 +78,7 @@ def save_transcription(filename, transcription, output_dir):
     
     return output_path
 
-def process_all_audio_files(model="chirp"):
+def process_all_audio_files(model="chirp_3"):
     """dataディレクトリ内のすべての音声ファイルを処理"""
     # パスの設定
     base_dir = Path(__file__).parent.parent
@@ -133,9 +134,9 @@ def process_all_audio_files(model="chirp"):
 
 if __name__ == "__main__":
     import argparse
-    parser = argparse.ArgumentParser(description='Google Cloud Speech-to-Text (Chirp/Chirp2)')
-    parser.add_argument('--model', choices=['chirp', 'chirp_2'], default='chirp',
-                        help='使用するモデル (default: chirp)')
+    parser = argparse.ArgumentParser(description='Google Cloud Speech-to-Text (Chirp)')
+    parser.add_argument('--model', choices=['chirp', 'chirp_2', 'chirp_3'], default='chirp_3',
+                        help='使用するモデル (default: chirp_3)')
     args = parser.parse_args()
     
     process_all_audio_files(model=args.model)

--- a/scripts/transcribe_openai.py
+++ b/scripts/transcribe_openai.py
@@ -19,7 +19,7 @@ def transcribe_audio_file(audio_file_path):
     try:
         with open(audio_file_path, "rb") as audio_file:
             transcription = client.audio.transcriptions.create(
-                model="gpt-4o-transcribe",  # 現在利用可能なモデルです
+                model="gpt-transcribe",
                 file=audio_file
             )
             return transcription.text

--- a/src/services/rag_service.py
+++ b/src/services/rag_service.py
@@ -31,8 +31,8 @@ logger = logging.getLogger(__name__)
 DEFAULT_CHUNK_SIZE = int(os.getenv("RAG_CHUNK_SIZE", "600"))
 DEFAULT_CHUNK_OVERLAP = int(os.getenv("RAG_CHUNK_OVERLAP", "120"))
 EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
-# 2025-10 時点：gpt-5 系列を既定に（Responses API 対応、品質/コスパ良好）。
-COMPLETION_MODEL = os.getenv("RAG_COMPLETION_MODEL", "gpt-5-mini")
+# Responses API 対応モデルを既定に。
+COMPLETION_MODEL = os.getenv("RAG_COMPLETION_MODEL", "gpt-5.6-luna")
 ENABLE_RAG = os.getenv("ENABLE_RAG", "true").lower() in {"1", "true", "yes", "on"}
 
 # Hybrid search parameters


### PR DESCRIPTION
## 概要

- RAG既定モデルを `gpt-5.6-luna` へ更新
- OpenAI文字起こしを `gpt-transcribe` へ更新
- ElevenLabs文字起こしを `scribe_v2` へ更新
- Google Cloud Speech-to-Textを `chirp_3` 既定へ更新し、ロケーション設定を環境変数化
- 設定例と開発ドキュメントを同期

## 検証

- Python `compileall`
- Google STT CLIのモデル選択・ヘルプ表示
- `gpt-5.6-luna` / `gpt-transcribe` / `scribe_v2` の既存APIキーによる疎通確認
- `git diff --check`

Google Chirp 3の実API疎通は、ローカルにApplication Default Credentialsがないため未実施です。