### PR TITLE
発言単位タイムスタンプの保存とRAGでの利用(課題198)+ タイムゾーンバグ修正

### DIFF
--- a/scripts/transcribe_elevenlabs.py
+++ b/scripts/transcribe_elevenlabs.py
@@ -61,15 +61,39 @@ def _clean_transcript(text: str) -> str:
     return out
 
 
-def transcribe_audio_file(audio_file_path, language_code=None):
-    """ElevenLabs Scribeで音声ファイルを文字起こしする
-    
-    Args:
-        audio_file_path: 音声ファイルのパス
-        language_code: 言語コード (例: "ja", "en") - Noneの場合は自動検出
-    
+def _extract_words(result) -> "list[dict] | None":
+    """APIレスポンスから単語タイムスタンプを取り出す。
+
+    stt-desktop が `word_timestamps_json` に保存するのと同じ
+    「単語オブジェクトの配列」形式({text, start, end, type, speaker_id?})。
+    characters(文字単位詳細)とlogprobはサイズ削減のため保存しない。
+    """
+    words = getattr(result, "words", None)
+    if not words:
+        return None
+    out: list[dict] = []
+    for w in words:
+        item: dict = {"text": getattr(w, "text", "") or ""}
+        for key in ("start", "end"):
+            value = getattr(w, key, None)
+            if isinstance(value, (int, float)):
+                item[key] = float(value)
+        word_type = getattr(w, "type", None)
+        if word_type:
+            item["type"] = str(word_type)
+        speaker_id = getattr(w, "speaker_id", None)
+        if speaker_id:
+            item["speaker_id"] = str(speaker_id)
+        out.append(item)
+    return out or None
+
+
+def transcribe_audio_file_detailed(audio_file_path, language_code=None):
+    """ElevenLabs Scribeで文字起こしし、単語タイムスタンプ付きで返す。
+
     Returns:
-        文字起こし結果のテキスト または (None, エラーメッセージ) のタプル
+        {"text": str|None, "words": list[dict]|None, "error": str|None}
+        words の各要素は {text, start, end, type, speaker_id?}(秒、STT入力音声基準)。
     """
     logger.info(f"処理開始: {audio_file_path}")
     logger.debug(f"ファイルパス: {audio_file_path}, 言語コード: {language_code}")
@@ -125,25 +149,48 @@ def transcribe_audio_file(audio_file_path, language_code=None):
         except Exception:
             pass
 
+        try:
+            words = _extract_words(result)
+            if words:
+                logger.debug(f"単語タイムスタンプ: {len(words)}要素")
+        except Exception as e:
+            logger.warning(f"単語タイムスタンプの抽出に失敗（本文のみ返却）: {e}")
+            words = None
+
         if result.text:
             cleaned = _clean_transcript(result.text)
             logger.info(f"文字起こし成功: {len(cleaned)}文字")
-            return cleaned
+            return {"text": cleaned, "words": words, "error": None}
         else:
             # 結果が複数のセグメントに分かれている場合
             if hasattr(result, 'segments'):
                 transcription = " ".join([getattr(segment, "text", "") for segment in result.segments]).strip()
                 cleaned = _clean_transcript(transcription)
                 logger.info(f"文字起こし成功（セグメント結合）: {len(cleaned)}文字")
-                return cleaned
+                return {"text": cleaned, "words": words, "error": None}
             logger.warning("文字起こし結果が空です")
-            return None
-            
+            return {"text": None, "words": None, "error": None}
+
     except Exception as e:
         error_msg = f"{audio_file_path} の処理中にエラーが発生しました: {type(e).__name__}: {str(e)}"
         logger.error(error_msg, exc_info=True)
-        # エラー情報を含むタプルを返す
-        return (None, error_msg)
+        return {"text": None, "words": None, "error": error_msg}
+
+
+def transcribe_audio_file(audio_file_path, language_code=None):
+    """ElevenLabs Scribeで音声ファイルを文字起こしする（従来互換）
+
+    Args:
+        audio_file_path: 音声ファイルのパス
+        language_code: 言語コード (例: "ja", "en") - Noneの場合は自動検出
+
+    Returns:
+        文字起こし結果のテキスト または (None, エラーメッセージ) のタプル
+    """
+    detailed = transcribe_audio_file_detailed(audio_file_path, language_code)
+    if detailed["error"]:
+        return (None, detailed["error"])
+    return detailed["text"]
 
 def save_transcription(filename, transcription, output_dir):
     """文字起こし結果をテキストファイルとして保存"""

--- a/src/models.py
+++ b/src/models.py
@@ -2,7 +2,7 @@ import logging
 import time
 import os
 from array import array
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Sequence
 
 from dotenv import load_dotenv
@@ -23,7 +23,7 @@ from sqlalchemy import (
 from sqlalchemy.engine import make_url
 from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship, sessionmaker
+from sqlalchemy.orm import deferred, relationship, sessionmaker
 from sqlalchemy.types import UserDefinedType
 
 # Postgres(pgvector)対応は廃止。libSQL専用。
@@ -36,6 +36,19 @@ logger = logging.getLogger(__name__)
 Base = declarative_base()
 
 EMBEDDING_DIM = int(os.getenv("EMBEDDING_DIM", "1536"))
+
+
+def utcnow_naive() -> datetime:
+    """UTC現在時刻をnaiveで返す(created_at列の書き込み用)。
+
+    created_at はDB全体で「naive UTC」に統一する。デスクトップ版はUTCの
+    RFC3339文字列を書き込んでおり、日付判定(services/rag/reconcile.py の
+    normalize_to_jst_date)はnaive値をUTCとして解釈する。bare datetime.now()
+    だとサーバーのローカルTZに依存し、JSTマシンで動かすと9時間ズレるため、
+    必ずこの関数を使う。aware値を書くとSQLiteの文字列形式が変わり
+    デスクトップ版との互換性に影響するため、naiveへ落とす。
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 def _is_libsql(url: str) -> bool:
@@ -80,8 +93,8 @@ class AudioTranscription(Base):
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     file_path = Column(String(500), nullable=False)
-    created_at = Column(DateTime, nullable=False, default=datetime.now)
-    # 正規化済みの録音日(JST, 'YYYY-MM-DD')。created_atはWeb版(naive JST)と
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive)
+    # 正規化済みの録音日(JST, 'YYYY-MM-DD')。created_atはWeb版(naive UTC)と
     # デスクトップ版(UTC RFC3339)で形式が異なるため、検索はこの列で行う。
     recorded_date = Column(String(10), nullable=True, index=True)
     duration_seconds = Column(Float, nullable=False)
@@ -90,6 +103,12 @@ class AudioTranscription(Base):
     tags = Column(String(200), nullable=True)
     model_id = Column(String(100), nullable=True)
     language_code = Column(String(10), nullable=True)
+    # 単語タイムスタンプ({text, start, end, type, speaker_id?}の配列)。
+    # stt-desktop と同名・同形式。_json はSTTが返したまま(VAD後音声基準)、
+    # _original_json はVAD前=元音声基準へ復元した値。サイズが大きいため
+    # 通常のSELECTでは読み込まない(deferred)。
+    word_timestamps_json = deferred(Column(JSON, nullable=True))
+    word_timestamps_original_json = deferred(Column(JSON, nullable=True))
     chunks = relationship(
         "AudioTranscriptionChunk",
         back_populates="transcription",
@@ -124,7 +143,10 @@ class CeoTranscription(Base):
     structured_json = Column(JSON, nullable=True)
     duration_seconds = Column(Float, nullable=True)
     tags = Column(String(200), nullable=True)
-    created_at = Column(DateTime, nullable=False, default=datetime.now)
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive)
+    # 単語タイムスタンプ(audio_transcriptionsと同形式)
+    word_timestamps_json = deferred(Column(JSON, nullable=True))
+    word_timestamps_original_json = deferred(Column(JSON, nullable=True))
 
     def __repr__(self):
         return f"<CeoTranscription(id={self.id}, title={self.title})>"
@@ -213,12 +235,18 @@ class AudioTranscriptionChunk(Base):
     )
     chunk_index = Column(Integer, nullable=False)
     chunk_text = Column(Text, nullable=False)
+    # チャンクの録音内時刻範囲(秒)。time_basisは時刻の基準:
+    # "original"=VAD前の元音声基準 / "vad"=VAD後音声基準(元音声とズレの可能性)。
+    # 単語タイムスタンプが無い録音ではNULL(従来動作)。
+    start_sec = Column(Float, nullable=True)
+    end_sec = Column(Float, nullable=True)
+    time_basis = Column(String(16), nullable=True)
     if VECTOR_BACKEND == "libsql":
         embedding = Column(LibSQLF32Vector(EMBEDDING_DIM), nullable=False)
     else:
         # ローカルSQLite（非libSQL）の場合はRAG無効のためJSONで可
         embedding = Column(JSON, nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at = Column(DateTime, default=utcnow_naive, nullable=False)
 
     transcription = relationship("AudioTranscription", back_populates="chunks")
 
@@ -236,11 +264,15 @@ class CeoTranscriptionChunk(Base):
     )
     chunk_index = Column(Integer, nullable=False)
     chunk_text = Column(Text, nullable=False)
+    # audio_transcription_chunks と同じ時刻範囲カラム
+    start_sec = Column(Float, nullable=True)
+    end_sec = Column(Float, nullable=True)
+    time_basis = Column(String(16), nullable=True)
     if VECTOR_BACKEND == "libsql":
         embedding = Column(LibSQLF32Vector(EMBEDDING_DIM), nullable=False)
     else:
         embedding = Column(JSON, nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at = Column(DateTime, default=utcnow_naive, nullable=False)
 
 
 class RAGChatLog(Base):
@@ -249,7 +281,7 @@ class RAGChatLog(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     session_id = Column(String(36), nullable=True, index=True)  # セッション管理用UUID
     chat_kind = Column(String(20), nullable=True)  # "audio"(現場録音) / "ceo"(社長音声)。NULLは旧データ=audio扱い
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at = Column(DateTime, default=utcnow_naive, nullable=False)
     user_text = Column(Text, nullable=False)
     answer_text = Column(Text, nullable=True)
     contexts = Column(JSON, nullable=True)  # 参照したチャンクやスコアを保持
@@ -269,8 +301,21 @@ def _tolerant_json_loads(value):
         return None
 
 
+def _compact_json_dumps(value) -> str:
+    """JSON列の書き込み。word_timestamps_json のような大きい配列で
+    ASCIIエスケープ(\\uXXXX)がサイズを数倍にするため、UTF-8のまま
+    コンパクトに書く(デスクトップ版 serde_json と同じ方針)。"""
+    import json as _json
+
+    return _json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
 # データベース接続設定
-engine_kwargs = dict(echo=False, json_deserializer=_tolerant_json_loads)
+engine_kwargs = dict(
+    echo=False,
+    json_deserializer=_tolerant_json_loads,
+    json_serializer=_compact_json_dumps,
+)
 if IS_LIBSQL:
     engine_kwargs["pool_pre_ping"] = True
 
@@ -326,7 +371,16 @@ def _ensure_columns(table_name: str, columns: dict[str, str]) -> None:
         logger.warning("%s のカラム追加に失敗: %s", table_name, exc)
 
 
-_ensure_columns("audio_transcriptions", {"recorded_date": "TEXT"})
+_ensure_columns(
+    "audio_transcriptions",
+    {
+        "recorded_date": "TEXT",
+        # 単語タイムスタンプ(stt-desktop の ensure_tables と同名・同形式。
+        # desktop側で作成済みのDBでは既存カラムのため何もしない=冪等)
+        "word_timestamps_json": "TEXT",
+        "word_timestamps_original_json": "TEXT",
+    },
+)
 
 _ensure_columns("rag_chat_logs", {"chat_kind": "TEXT"})
 
@@ -352,8 +406,21 @@ _ensure_columns(
         "duration_seconds": "REAL",
         "tags": "TEXT",
         "created_at": "TEXT",
+        "word_timestamps_json": "TEXT",
+        "word_timestamps_original_json": "TEXT",
     },
 )
+
+# RAGチャンクの録音内時刻範囲(発言単位タイムスタンプのRAG利用)
+for _chunk_table in ("audio_transcription_chunks", "ceo_transcription_chunks"):
+    _ensure_columns(
+        _chunk_table,
+        {
+            "start_sec": "REAL",
+            "end_sec": "REAL",
+            "time_basis": "TEXT",
+        },
+    )
 
 # セッション作成
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/src/services/ceo_processor.py
+++ b/src/services/ceo_processor.py
@@ -24,10 +24,11 @@ from typing import Optional
 
 from sqlalchemy import or_
 
-from models import CeoTranscription, get_db
+from models import CeoTranscription, get_db, utcnow_naive
 from services.audio_utils import get_audio_duration, get_audio_duration_metadata
 from services.rag_service import get_rag_service
 from services.vad import trim_non_speech
+from services.word_timestamps import build_word_timestamp_columns
 from stt_wrapper import STTModelWrapper
 
 
@@ -433,6 +434,8 @@ def process_ceo_uploaded_path(
 
         # 3. VAD（任意）
         stt_input_path = str(src)
+        vad_applied = False  # STT入力がVADトリム後音声か
+        vad_kept_ranges = None
         if use_vad and _should_apply_vad(
             file_path=str(src),
             size_bytes=source_file_size_bytes,
@@ -446,6 +449,8 @@ def process_ceo_uploaded_path(
                 )
                 vad_path = vad_res.output_path
                 stt_input_path = vad_path
+                vad_applied = True
+                vad_kept_ranges = vad_res.kept_ranges
                 original_duration = vad_res.orig_sec
                 if vad_res.orig_sec > 0:
                     reduced = max(0.0, 1.0 - (vad_res.out_sec / vad_res.orig_sec)) * 100.0
@@ -459,6 +464,8 @@ def process_ceo_uploaded_path(
                 logger.warning("CEO VAD 前処理に失敗したためスキップ: %s", exc)
                 _append_warning(result, f"VAD 前処理に失敗したため元音声を使用します: {exc}")
                 stt_input_path = str(src)
+                vad_applied = False
+                vad_kept_ranges = None
 
         # 4. VAD ファイルはマイク録音用の保存先（CEO_VAD_OUTPUT_DIR）にコピー保存
         if vad_path and os.path.exists(vad_path):
@@ -472,10 +479,10 @@ def process_ceo_uploaded_path(
 
         # 5. STT
         wrapper = STTModelWrapper(selected_model)
-        transcription = wrapper.transcribe(stt_input_path)
-        error_msg: Optional[str] = None
-        if isinstance(transcription, tuple) and transcription[0] is None:
-            error_msg = transcription[1] if len(transcription) > 1 else "STT failed"
+        stt_result = wrapper.transcribe_detailed(stt_input_path)
+        transcription = stt_result.text
+        error_msg: Optional[str] = stt_result.error
+        if error_msg:
             transcription = None
 
         if not transcription:
@@ -484,6 +491,14 @@ def process_ceo_uploaded_path(
             return result
 
         duration = original_duration or _safe_duration(str(src), stt_input_path)
+
+        # 単語タイムスタンプ: VAD後基準(STTが返したまま)と、VAD保持区間から
+        # 元音声基準へ復元した値の両方を保存する(desktopの作業録音と同方針)
+        word_ts, word_ts_original = build_word_timestamp_columns(
+            stt_result.words,
+            vad_applied=vad_applied,
+            vad_ranges=vad_kept_ranges,
+        )
 
         # 6. DB 保存
         db = next(get_db())
@@ -507,7 +522,10 @@ def process_ceo_uploaded_path(
                 structured_json=None,
                 duration_seconds=duration,
                 tags="社長音声",
-                created_at=datetime.now(),
+                # naive UTCで統一(日付判定はUTC解釈のため。models.utcnow_naive参照)
+                created_at=utcnow_naive(),
+                word_timestamps_json=word_ts,
+                word_timestamps_original_json=word_ts_original,
             )
             db.add(record)
             db.flush()

--- a/src/services/rag/chunk_timing.py
+++ b/src/services/rag/chunk_timing.py
@@ -1,0 +1,152 @@
+"""チャンクへの録音内時刻(start_sec/end_sec)割り当て。
+
+単語タイムスタンプ(word_timestamps_*_json)とチャンクテキストを文字位置
+ベースで対応付ける近似ロジック。チャンカー(chunker.py)は文単位で空白を
+除去して連結するため、空白を除去した正規化空間で位置合わせを行う。
+
+- 時刻の基準は word_timestamps_original_json(VAD前=元音声基準)を優先し、
+  無い行のみ word_timestamps_json(VAD後基準)を使う。どちらを使ったかは
+  time_basis("original" / "vad")としてチャンクに記録する。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from bisect import bisect_left, bisect_right
+from typing import Any, Dict, List, Optional, Tuple
+
+from services.word_timestamps import get_word_time_range
+
+logger = logging.getLogger(__name__)
+
+TIME_BASIS_ORIGINAL = "original"  # VAD前(元音声)基準
+TIME_BASIS_VAD = "vad"  # VAD後音声基準(元音声の再生位置とズレの可能性あり)
+
+_WS_RE = re.compile(r"\s+")
+
+
+def _normalize(text: str) -> str:
+    """空白類を除去する(チャンカーの文strip・連結と整合させるため)。"""
+    return _WS_RE.sub("", text or "")
+
+
+def parse_words_json(value: Any) -> Optional[List[Dict[str, Any]]]:
+    """word_timestamps_*_json 列の値を単語配列として解釈する(寛容)。"""
+    if value is None:
+        return None
+    parsed = value
+    if isinstance(value, (str, bytes)):
+        raw = value.strip() if isinstance(value, str) else value
+        if not raw:
+            return None
+        try:
+            parsed = json.loads(raw)
+        except (ValueError, TypeError):
+            logger.warning("word_timestampsのJSONパースに失敗したため無視します")
+            return None
+    if not isinstance(parsed, list):
+        return None
+    words = [w for w in parsed if isinstance(w, dict)]
+    return words or None
+
+
+def select_timing_words(
+    word_timestamps_json: Any,
+    word_timestamps_original_json: Any,
+) -> Tuple[Optional[List[Dict[str, Any]]], Optional[str]]:
+    """時刻割り当てに使う単語列と基準(time_basis)を決める。
+
+    original(VAD前基準)があればそれを使う。無ければraw(VAD後基準)に
+    フォールバックし、基準が元音声とズレうることを "vad" として返す。
+    """
+    original = parse_words_json(word_timestamps_original_json)
+    if original:
+        return original, TIME_BASIS_ORIGINAL
+    raw = parse_words_json(word_timestamps_json)
+    if raw:
+        return raw, TIME_BASIS_VAD
+    return None, None
+
+
+def assign_chunk_times(
+    transcript: str,
+    chunks: List[str],
+    words: Optional[List[Dict[str, Any]]],
+    chunk_overlap: int = 120,
+) -> List[Tuple[Optional[float], Optional[float]]]:
+    """各チャンクに録音内時刻範囲(開始秒, 終了秒)を割り当てる。
+
+    - チャンクの位置は「空白除去した本文」内の文字位置で特定する
+      (チャンカーは文をstripして連結するため、正規化すれば完全一致する)。
+    - 文字位置→時刻は、単語テキストを同様に正規化して連結したときの
+      文字オフセットで対応付ける。本文と単語連結の長さが異なる場合
+      (クレンジング差分等)は比例スケーリングで近似する。
+    - chunk_overlapにはチャンク化時のオーバーラップ文字数を渡す。次チャンクの
+      探索開始位置を「前チャンク終端-オーバーラップ」に制限することで、
+      同じ文言が繰り返される本文でも手前の同一文字列に誤マッチしない。
+    - 対応付けできないチャンクは (None, None)。
+    """
+    n = len(chunks)
+    empty: List[Tuple[Optional[float], Optional[float]]] = [(None, None)] * n
+    if not chunks or not words:
+        return empty
+
+    t_norm = _normalize(transcript)
+    if not t_norm:
+        return empty
+
+    # 単語→正規化空間の文字オフセット表(時刻を持つ単語のみentriesに載せる)
+    entries: List[Tuple[int, int, float, float]] = []  # (norm_start, norm_end, t_start, t_end)
+    total = 0
+    for w in words:
+        text = _normalize(str(w.get("text", "")))
+        length = len(text)
+        if length == 0:
+            continue  # spacing等は正規化空間に現れない
+        start_sec, end_sec = get_word_time_range(w)
+        if start_sec is not None:
+            if end_sec is None or end_sec < start_sec:
+                end_sec = start_sec
+            entries.append((total, total + length, float(start_sec), float(end_sec)))
+        total += length
+
+    if total == 0 or not entries:
+        return empty
+
+    scale = total / len(t_norm)
+    entry_starts = [e[0] for e in entries]
+    entry_ends = [e[1] for e in entries]
+
+    overlap_bound = max(0, int(chunk_overlap))
+    results: List[Tuple[Optional[float], Optional[float]]] = []
+    cursor = 0
+    for chunk in chunks:
+        c_norm = _normalize(chunk)
+        if not c_norm:
+            results.append((None, None))
+            continue
+        idx = t_norm.find(c_norm, cursor)
+        if idx < 0:
+            idx = t_norm.find(c_norm)
+        if idx < 0:
+            results.append((None, None))
+            continue
+        # 次チャンクは「このチャンクの終端 - オーバーラップ」以降から始まる
+        # (正規化でオーバーラップ部分が縮むことはあっても伸びることはない)
+        cursor = max(cursor, idx + len(c_norm) - overlap_bound)
+
+        lo = idx * scale
+        hi = (idx + len(c_norm)) * scale
+        # [lo, hi) と重なる最初/最後の単語entryを二分探索で求める
+        first = bisect_right(entry_ends, lo)
+        last = bisect_left(entry_starts, hi) - 1
+        if first > last or first >= len(entries) or last < 0:
+            results.append((None, None))
+            continue
+        start_sec = entries[first][2]
+        end_sec = max(entries[last][3], start_sec)
+        results.append((round(start_sec, 3), round(end_sec, 3)))
+
+    return results

--- a/src/services/rag/context_builder.py
+++ b/src/services/rag/context_builder.py
@@ -3,12 +3,15 @@
 チャンク断片をそのまま渡すのではなく、録音単位にグループ化して
 「短い録音は全文、長い録音はヒット周辺の連続ウィンドウ」を渡す。
 文脈が保たれるため、要約系・履歴参照系の質問に強くなる。
+
+チャンクに録音内時刻(start_sec/end_sec)がある録音では、本文の各チャンクに
+[MM:SS〜MM:SS] 形式の時刻ラベルを付けて渡す(発言時刻を回答で引用するため)。
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, asdict
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 from sqlalchemy import text
 from sqlalchemy.orm import Session
@@ -32,18 +35,45 @@ class ContextDoc:
     hit_count: int
     is_full_text: bool
     truncated: bool
+    # 本文中の [MM:SS〜MM:SS] の基準。"original"=元音声基準 /
+    # "vad"=無音カット(VAD)後基準(元音声の再生位置とズレの可能性) / None=時刻なし
+    time_basis: Optional[str] = None
 
     def to_dict(self) -> Dict:
         return asdict(self)
 
 
-def _join_with_overlap(a: str, b: str, max_overlap: int = 200) -> str:
-    """チャンク化時のオーバーラップ(既定120文字)を検出して重複なしに連結。"""
+@dataclass
+class _ChunkRow:
+    index: int
+    text: str
+    start_sec: Optional[float] = None
+    end_sec: Optional[float] = None
+    time_basis: Optional[str] = None
+
+    @property
+    def has_time(self) -> bool:
+        return self.start_sec is not None and self.end_sec is not None
+
+
+def _overlap_len(a: str, b: str, max_overlap: int = 200) -> int:
+    """aの末尾とbの先頭の重複文字数(チャンク化時のオーバーラップ)を検出。"""
     limit = min(len(a), len(b), max_overlap)
     for k in range(limit, 0, -1):
         if a.endswith(b[:k]):
-            return a + b[k:]
-    return a + b
+            return k
+    return 0
+
+
+def _join_with_overlap(a: str, b: str, max_overlap: int = 200) -> str:
+    """チャンク化時のオーバーラップ(既定120文字)を検出して重複なしに連結。"""
+    return a + b[_overlap_len(a, b, max_overlap):]
+
+
+def _format_mmss(seconds: float) -> str:
+    """録音開始からの経過秒を MM:SS 形式にする(60分以上は分が2桁を超える)。"""
+    total = max(0, int(round(seconds)))
+    return f"{total // 60:02d}:{total % 60:02d}"
 
 
 def _merge_chunk_windows(
@@ -75,6 +105,80 @@ def _merge_chunk_windows(
     if current:
         parts.append(current)
     return "\n（…中略…）\n".join(parts)
+
+
+def _merge_timed_chunk_windows(
+    chunk_rows: Sequence[_ChunkRow],
+    keep_indexes: set,
+) -> str:
+    """時刻付きチャンクを [MM:SS〜MM:SS] ラベル付きの行として結合する。
+
+    連続チャンクはオーバーラップ(前チャンク末尾との重複)を除去し、
+    除去分だけラベルの開始時刻を線形補間で進める。間隙は省略記号で示す。
+    時刻の無いチャンクはラベルなしの行になる。
+    """
+    parts: List[str] = []
+    lines: List[str] = []
+    prev_idx: Optional[int] = None
+    prev_text: Optional[str] = None
+    for row in chunk_rows:
+        if row.index not in keep_indexes:
+            continue
+        if prev_idx is not None and row.index == prev_idx + 1 and prev_text is not None:
+            k = _overlap_len(prev_text, row.text)
+        else:
+            if lines:
+                parts.append("\n".join(lines))
+                lines = []
+            k = 0
+        prev_idx, prev_text = row.index, row.text
+        shown = row.text[k:]
+        if not shown:
+            continue
+        if row.has_time:
+            display_start = row.start_sec
+            if k > 0 and len(row.text) > 0:
+                # 重複除去した先頭分だけ開始時刻を進める(近似)
+                display_start = row.start_sec + (row.end_sec - row.start_sec) * (
+                    k / len(row.text)
+                )
+            label = f"[{_format_mmss(display_start)}〜{_format_mmss(row.end_sec)}] "
+        else:
+            label = ""
+        lines.append(label + shown)
+    if lines:
+        parts.append("\n".join(lines))
+    return "\n（…中略…）\n".join(parts)
+
+
+def _fetch_chunk_rows(db: Session, chunk_table: str, transcription_id: int) -> List[_ChunkRow]:
+    rows = db.execute(
+        text(
+            f"SELECT chunk_index, chunk_text, start_sec, end_sec, time_basis "
+            f"FROM {chunk_table} "
+            f"WHERE transcription_id = :id ORDER BY chunk_index"
+        ),
+        {"id": transcription_id},
+    ).mappings().all()
+    out: List[_ChunkRow] = []
+    for r in rows:
+        start_sec = r["start_sec"]
+        end_sec = r["end_sec"]
+        try:
+            start_sec = float(start_sec) if start_sec is not None else None
+            end_sec = float(end_sec) if end_sec is not None else None
+        except (TypeError, ValueError):
+            start_sec = end_sec = None
+        out.append(
+            _ChunkRow(
+                index=int(r["chunk_index"]),
+                text=r["chunk_text"] or "",
+                start_sec=start_sec,
+                end_sec=end_sec if start_sec is not None else None,
+                time_basis=r["time_basis"],
+            )
+        )
+    return out
 
 
 def build_context_docs(
@@ -136,22 +240,43 @@ def build_context_docs(
             continue
         transcript = row["transcript"]
 
+        chunk_rows = _fetch_chunk_rows(db, chunk_table, g["transcription_id"])
+        timed = any(r.has_time for r in chunk_rows)
+        time_basis: Optional[str] = None
+        if timed:
+            time_basis = next((r.time_basis for r in chunk_rows if r.time_basis), None)
+
         is_full = len(transcript) <= whole_doc_threshold
         if is_full:
-            body = transcript
+            if timed:
+                # 全文でも時刻ラベルを付けるため、全チャンクを結合して構成する
+                # (チャンクは文単位で全文を覆うため内容は全文と同等)
+                body = _merge_timed_chunk_windows(
+                    chunk_rows, {r.index for r in chunk_rows}
+                )
+                if not body:
+                    body = transcript
+            else:
+                body = transcript
         else:
-            chunk_rows = db.execute(
-                text(
-                    f"SELECT chunk_index, chunk_text FROM {chunk_table} "
-                    f"WHERE transcription_id = :id ORDER BY chunk_index"
-                ),
-                {"id": g["transcription_id"]},
-            ).mappings().all()
-            ordered_chunks = [(int(r["chunk_index"]), r["chunk_text"] or "") for r in chunk_rows]
+            ordered_chunks = [(r.index, r.text) for r in chunk_rows]
             if g["hit_indexes"] and ordered_chunks:
-                body = _merge_chunk_windows(ordered_chunks, g["hit_indexes"], neighbor_window)
+                keep: set = set()
+                for idx in g["hit_indexes"]:
+                    for i in range(idx - neighbor_window, idx + neighbor_window + 1):
+                        keep.add(i)
+                if timed:
+                    body = _merge_timed_chunk_windows(chunk_rows, keep)
+                else:
+                    body = _merge_chunk_windows(
+                        ordered_chunks, g["hit_indexes"], neighbor_window
+                    )
             else:
                 body = transcript  # チャンク情報がない場合は全文(後段で切り詰め)
+                time_basis = None
+
+        if not timed:
+            time_basis = None
 
         truncated = False
         budget = min(per_doc_cap, max_chars - used_chars)
@@ -172,6 +297,7 @@ def build_context_docs(
                 hit_count=len(g["hit_indexes"]) or 1,
                 is_full_text=is_full,
                 truncated=truncated,
+                time_basis=time_basis,
             )
         )
         used_chars += len(body)

--- a/src/services/rag/date_utils.py
+++ b/src/services/rag/date_utils.py
@@ -8,11 +8,23 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Optional
 
 # 「最近」の既定ウィンドウ(日)
 RECENCY_DAYS = 30
+
+JST = timezone(timedelta(hours=9), name="JST")
+
+
+def jst_today() -> date:
+    """JSTでの「今日」。
+
+    サーバー(Streamlit Community Cloud)はUTCで動くため、bare date.today()だと
+    JST 0時〜9時の間は前日になる。「今日」「昨日」等の相対日付判定と
+    プロンプトの今日日付には必ずこちらを使う。
+    """
+    return datetime.now(JST).date()
 
 
 @dataclass(frozen=True)
@@ -116,8 +128,11 @@ def _parse_date_range_expr(q: str, today: date) -> Optional[DateRange]:
 
 
 def parse_date_from_query(query: str, today: Optional[date] = None) -> Optional[DateRange]:
-    """クエリから日付範囲を抽出する。より具体的な表現を優先する。"""
-    today = today or date.today()
+    """クエリから日付範囲を抽出する。より具体的な表現を優先する。
+
+    todayを省略した場合はJSTの今日を使う(サーバーローカルではない)。
+    """
+    today = today or jst_today()
     q = query or ""
 
     # --- 範囲表現 (2025/1/01～2025/01/16 / 7月1日から7月15日まで) ---

--- a/src/services/rag/prompt_builder.py
+++ b/src/services/rag/prompt_builder.py
@@ -6,6 +6,7 @@ from datetime import date
 from typing import Dict, List, Optional
 
 from services.rag.context_builder import ContextDoc
+from services.rag.date_utils import jst_today
 
 _SOURCE_LABELS = {"audio": "現場録音", "ceo": "社長音声"}
 
@@ -17,7 +18,7 @@ _CORPUS_DESCRIPTIONS = {
 
 
 def build_system_prompt(today: Optional[date] = None, corpus: str = "audio") -> str:
-    today_str = (today or date.today()).isoformat()
+    today_str = (today or jst_today()).isoformat()
     corpus_desc = _CORPUS_DESCRIPTIONS.get(corpus, _CORPUS_DESCRIPTIONS["audio"])
     return (
         "あなたは射出成形工場の社内アシスタントです。"
@@ -28,6 +29,7 @@ def build_system_prompt(today: Optional[date] = None, corpus: str = "audio") -> 
         "- コンテキストは音声の自動文字起こしのため、誤変換や言い淀みが含まれうる。文脈から明らかな誤変換は補って解釈してよいが、推測した場合はその旨を付記する\n"
         "- 回答の形式は質問の指定に従う(表形式・報告書形式など)。指定がなければ簡潔な箇条書き\n"
         "- 日付は YYYY-MM-DD 形式で明示する\n"
+        "- コンテキスト本文の [MM:SS〜MM:SS] は録音開始からの経過時間。発言時刻(録音内の経過時間)を引用する際は MM:SS 形式で明示する\n"
         "- コンテキストに根拠がない事項は推測せず、「記録には見つからない」と正直に述べる\n"
         "- 会話の文脈を維持し、直前のやり取りとの関連を保つ"
     )
@@ -44,6 +46,13 @@ def format_context_block(docs: List[ContextDoc]) -> str:
         meta_parts.append(_SOURCE_LABELS.get(d.source, d.source))
         if not d.is_full_text:
             meta_parts.append("※関連部分の抜粋")
+        if getattr(d, "time_basis", None) == "vad":
+            # 元音声基準(word_timestamps_original_json)が無い録音は
+            # 無音カット後の音声基準の時刻しか無いことを明示する
+            meta_parts.append(
+                "※録音内時刻は無音カット(VAD)後の音声基準のため、"
+                "元の録音の再生位置とはズレている可能性がある"
+            )
         header = f"[#{d.n}] " + " / ".join(meta_parts)
         blocks.append(f"{header}\n{d.text}")
     return "\n\n".join(blocks)

--- a/src/services/rag/reconcile.py
+++ b/src/services/rag/reconcile.py
@@ -10,18 +10,17 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from models import RAG_FTS_TABLES
+from services.rag.date_utils import JST  # noqa: F401  (後方互換の再エクスポート)
 from services.rag.tokenizer import to_fts_text
 
 logger = logging.getLogger(__name__)
-
-JST = timezone(timedelta(hours=9), name="JST")
 
 # 小数秒が6桁を超えるとdatetime.fromisoformatが失敗するため丸める
 _FRACTION_RE = re.compile(r"(\.\d{1,6})\d*")

--- a/src/services/rag_service.py
+++ b/src/services/rag_service.py
@@ -29,6 +29,7 @@ from models import (
 from sqlalchemy import text as sql_text
 
 from services.rag import chunk_text
+from services.rag.chunk_timing import assign_chunk_times, select_timing_words
 from services.rag.context_builder import ContextDoc, build_context_docs
 from services.rag.date_utils import DateRange, parse_date_from_query
 from services.rag.prompt_builder import build_chat_messages
@@ -137,12 +138,15 @@ class RAGService:
             logger.warning("RAG: 埋め込み生成に失敗したためスキップ (%s id=%s)", source, transcription_id)
             return False
 
-        # recorded_dateの補完(ORMロードは不正JSON列で失敗しうるため生SQL)
+        # recorded_dateの補完と単語タイムスタンプの取得
+        # (ORMロードは不正JSON列で失敗しうるため生SQL)
         parent_table = "audio_transcriptions" if source == "audio" else "ceo_transcriptions"
         date_source_col = "recorded_at" if source == "ceo" else "created_at"
         row = db.execute(
             sql_text(
-                f"SELECT recorded_date, {date_source_col}, created_at FROM {parent_table} WHERE id = :id"
+                f"SELECT recorded_date, {date_source_col}, created_at, "
+                f"word_timestamps_json, word_timestamps_original_json "
+                f"FROM {parent_table} WHERE id = :id"
             ),
             {"id": transcription_id},
         ).first()
@@ -157,6 +161,25 @@ class RAGService:
                 {"d": recorded_date, "id": transcription_id},
             )
 
+        # チャンクへの録音内時刻割り当て(単語タイムスタンプがある録音のみ)。
+        # デスクトップ版保存分(word_timestamps_jsonあり)も再同期経由でここを通る。
+        time_basis: Optional[str] = None
+        chunk_times: List[Tuple[Optional[float], Optional[float]]] = [(None, None)] * len(chunks)
+        if row is not None:
+            try:
+                timing_words, time_basis = select_timing_words(row[3], row[4])
+                if timing_words:
+                    chunk_times = assign_chunk_times(
+                        text, chunks, timing_words, chunk_overlap=DEFAULT_CHUNK_OVERLAP
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "チャンク時刻の割り当てに失敗したため時刻なしで索引します (%s id=%s): %s",
+                    source, transcription_id, exc,
+                )
+                time_basis = None
+                chunk_times = [(None, None)] * len(chunks)
+
         # 既存チャンク+FTS行を削除してから再作成
         old_ids = [
             r[0]
@@ -168,11 +191,15 @@ class RAGService:
 
         new_chunks = []
         for idx, (piece, embedding) in enumerate(zip(chunks, embeddings)):
+            start_sec, end_sec = chunk_times[idx] if idx < len(chunk_times) else (None, None)
             chunk = chunk_model(
                 transcription_id=transcription_id,
                 chunk_index=idx,
                 chunk_text=piece,
                 embedding=embedding,
+                start_sec=start_sec,
+                end_sec=end_sec,
+                time_basis=time_basis if start_sec is not None else None,
             )
             db.add(chunk)
             new_chunks.append(chunk)

--- a/src/services/vad.py
+++ b/src/services/vad.py
@@ -15,6 +15,20 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
+class VadTimeRange:
+    """VADで保持した区間の対応関係（元音声の時刻 ⇔ トリム後音声の時刻）。
+
+    stt-desktop の VadTimeRange (src-tauri/src/transcript.rs) と同じ意味。
+    STTが返すトリム後基準のタイムスタンプを元音声基準へ復元するために使う。
+    """
+
+    original_start: float
+    original_end: float
+    trimmed_start: float
+    trimmed_end: float
+
+
+@dataclass
 class VADResult:
     applied: bool
     method: str
@@ -22,6 +36,16 @@ class VADResult:
     output_path: str
     orig_sec: float
     out_sec: float
+    # 出力(トリム後)音声を構成する保持区間。トリムなし・フォールバック時は
+    # 全区間1件(恒等変換)。復元不能な場合のみNone。
+    kept_ranges: Optional[List[VadTimeRange]] = None
+
+
+def _identity_ranges(duration_sec: float) -> List[VadTimeRange]:
+    """出力=元音声(無変換)の場合の恒等区間。"""
+    if duration_sec <= 0:
+        return []
+    return [VadTimeRange(0.0, duration_sec, 0.0, duration_sec)]
 
 
 def _to_int16_pcm(x: np.ndarray) -> np.ndarray:
@@ -29,21 +53,31 @@ def _to_int16_pcm(x: np.ndarray) -> np.ndarray:
     return (x * 32767.0).astype(np.int16)
 
 
-def _energy_trim(audio: np.ndarray, sr: int, top_db: int = 30, pad_ms: int = 150) -> Tuple[np.ndarray, float]:
+def _energy_trim(
+    audio: np.ndarray, sr: int, top_db: int = 30, pad_ms: int = 150
+) -> Tuple[np.ndarray, float, List[VadTimeRange]]:
     """librosaのエネルギーベースで非音声（無音）をカットする簡易版。
     webrtcvadが使えない環境のフォールバックとして使用。
     """
     intervals = librosa.effects.split(audio, top_db=top_db)
     if intervals.size == 0:
-        return audio, float(len(audio) / sr)
+        dur = float(len(audio) / sr)
+        return audio, dur, _identity_ranges(dur)
     pad = int(sr * pad_ms / 1000)
     pieces: List[np.ndarray] = []
+    ranges: List[VadTimeRange] = []
+    cum = 0.0
     for start, end in intervals:
         s = max(0, start - pad)
         e = min(len(audio), end + pad)
-        pieces.append(audio[s:e])
+        piece = audio[s:e]
+        piece_sec = float(len(piece) / sr)
+        if piece_sec > 0:
+            ranges.append(VadTimeRange(s / sr, e / sr, cum, cum + piece_sec))
+            cum += piece_sec
+        pieces.append(piece)
     out = np.concatenate(pieces) if pieces else audio
-    return out, float(len(out) / sr)
+    return out, float(len(out) / sr), ranges
 
 
 def trim_non_speech(
@@ -77,7 +111,8 @@ def trim_non_speech(
         # 変換のみ: STTの互換性を維持するため16kHzに変換して保存
         audio_16k = librosa.resample(orig_audio, orig_sr=orig_sr, target_sr=target_sr) if orig_sr != target_sr else orig_audio
         sf.write(out_path, audio_16k, target_sr)
-        return VADResult(False, "none", input_path, out_path, orig_sec, float(len(audio_16k)/target_sr))
+        out_sec = float(len(audio_16k) / target_sr)
+        return VADResult(False, "none", input_path, out_path, orig_sec, out_sec, _identity_ranges(out_sec))
 
     try:
         import webrtcvad  # type: ignore
@@ -95,7 +130,8 @@ def trim_non_speech(
         if n_frames == 0:
             # きわめて短いファイルはスルー
             sf.write(out_path, audio_16k, target_sr)
-            return VADResult(True, "webrtcvad", input_path, out_path, orig_sec, float(len(audio_16k)/target_sr))
+            out_sec = float(len(audio_16k) / target_sr)
+            return VADResult(True, "webrtcvad", input_path, out_path, orig_sec, out_sec, _identity_ranges(out_sec))
 
         speech_flags = []
         for i in range(n_frames):
@@ -133,7 +169,8 @@ def trim_non_speech(
         if not segments:
             # すべて非音声と判定された場合は原音を書き出す
             sf.write(out_path, audio_16k, target_sr)
-            return VADResult(True, "webrtcvad_empty", input_path, out_path, orig_sec, float(len(audio_16k)/target_sr))
+            out_sec = float(len(audio_16k) / target_sr)
+            return VADResult(True, "webrtcvad_empty", input_path, out_path, orig_sec, out_sec, _identity_ranges(out_sec))
 
         pieces = [audio_16k[s:e] for s, e in segments]
         trimmed = np.concatenate(pieces) if pieces else audio_16k
@@ -142,21 +179,35 @@ def trim_non_speech(
         # 短すぎるとSTTが不安定になるのでフォールバック
         if out_sec * 1000 < min_out_ms:
             sf.write(out_path, audio_16k, target_sr)
-            return VADResult(True, "webrtcvad_short_fallback", input_path, out_path, orig_sec, float(len(audio_16k)/target_sr))
+            full_sec = float(len(audio_16k) / target_sr)
+            return VADResult(True, "webrtcvad_short_fallback", input_path, out_path, orig_sec, full_sec, _identity_ranges(full_sec))
+
+        # 保持区間(元音声時刻⇔トリム後時刻)を記録する
+        kept_ranges: List[VadTimeRange] = []
+        cum = 0.0
+        for s, e in segments:
+            piece_sec = float((e - s) / target_sr)
+            if piece_sec <= 0:
+                continue
+            kept_ranges.append(
+                VadTimeRange(s / target_sr, e / target_sr, cum, cum + piece_sec)
+            )
+            cum += piece_sec
 
         sf.write(out_path, trimmed, target_sr)
-        return VADResult(True, "webrtcvad", input_path, out_path, orig_sec, out_sec)
+        return VADResult(True, "webrtcvad", input_path, out_path, orig_sec, out_sec, kept_ranges)
 
     except Exception as e:
         logger.warning(f"webrtcvadが使用できないためエネルギートリムにフォールバックします: {e}")
         # フォールバック（エネルギーベース）
         audio_16k = librosa.resample(orig_audio, orig_sr=orig_sr, target_sr=target_sr) if orig_sr != target_sr else orig_audio
-        trimmed, out_sec = _energy_trim(audio_16k, target_sr, top_db=30, pad_ms=pad_ms)
+        trimmed, out_sec, kept_ranges = _energy_trim(audio_16k, target_sr, top_db=30, pad_ms=pad_ms)
         if out_sec * 1000 < min_out_ms:
             trimmed = audio_16k
             out_sec = float(len(trimmed) / target_sr)
             method = "energy_short_fallback"
+            kept_ranges = _identity_ranges(out_sec)
         else:
             method = "energy"
         sf.write(out_path, trimmed, target_sr)
-        return VADResult(True, method, input_path, out_path, orig_sec, out_sec)
+        return VADResult(True, method, input_path, out_path, orig_sec, out_sec, kept_ranges)

--- a/src/services/word_timestamps.py
+++ b/src/services/word_timestamps.py
@@ -1,0 +1,157 @@
+"""単語タイムスタンプ(word timestamps)の保存用ユーティリティ。
+
+stt-desktop と同じスキーマで `word_timestamps_json`(STTが返したまま=VAD後
+音声基準) と `word_timestamps_original_json`(VAD前=元音声基準に復元) の
+両方を保存するための変換を提供する。
+
+- 復元ロジックは stt-desktop の remap_word_timestamps_to_original
+  (src-tauri/src/transcript.rs) と同等。
+- VADを通らない経路ではSTTのタイムスタンプ=元音声基準なので両者は同値。
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from services.vad import VadTimeRange
+
+logger = logging.getLogger(__name__)
+
+# stt-desktop と同じキー候補(先頭が優先)
+_START_KEYS = ("start", "start_time", "startTime", "offset_start")
+_END_KEYS = ("end", "end_time", "endTime", "offset_end")
+
+
+def _to_float(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        f = float(value)
+    elif isinstance(value, str):
+        try:
+            f = float(value)
+        except ValueError:
+            return None
+    else:
+        return None
+    return f if math.isfinite(f) else None
+
+
+def _get_time_value(word: Dict[str, Any], keys: Sequence[str]) -> Optional[float]:
+    for key in keys:
+        if key in word:
+            seconds = _to_float(word[key])
+            if seconds is not None:
+                return seconds
+    return None
+
+
+def _set_time_value(word: Dict[str, Any], keys: Sequence[str], value: float) -> None:
+    for key in keys:
+        if key in word:
+            word[key] = value
+            return
+    word[keys[0]] = value
+
+
+def get_word_time_range(
+    word: Dict[str, Any],
+) -> Tuple[Optional[float], Optional[float]]:
+    """単語オブジェクトから (start秒, end秒) を取り出す(キー表記ゆれ対応)。"""
+    return _get_time_value(word, _START_KEYS), _get_time_value(word, _END_KEYS)
+
+
+def normalize_vad_ranges(
+    ranges: Optional[Sequence[VadTimeRange]],
+) -> List[VadTimeRange]:
+    """不正な区間を除外し、トリム後時刻の昇順に整列する。"""
+    if not ranges:
+        return []
+    out = [
+        r
+        for r in ranges
+        if math.isfinite(r.original_start)
+        and math.isfinite(r.original_end)
+        and math.isfinite(r.trimmed_start)
+        and math.isfinite(r.trimmed_end)
+        and r.original_end > r.original_start
+        and r.trimmed_end > r.trimmed_start
+    ]
+    out.sort(key=lambda r: r.trimmed_start)
+    return out
+
+
+def map_trimmed_to_original(
+    seconds: float, ranges: Sequence[VadTimeRange]
+) -> Optional[float]:
+    """トリム後音声の時刻(秒)を元音声の時刻へ写像する。範囲外はNone。"""
+    if not math.isfinite(seconds) or not ranges:
+        return None
+    for idx, r in enumerate(ranges):
+        is_last = idx + 1 == len(ranges)
+        if is_last:
+            in_range = r.trimmed_start - 1e-6 <= seconds <= r.trimmed_end + 1e-6
+        else:
+            in_range = r.trimmed_start - 1e-6 <= seconds < r.trimmed_end + 1e-6
+        if in_range:
+            max_delta = max(r.trimmed_end - r.trimmed_start, 0.0)
+            delta = min(max(seconds - r.trimmed_start, 0.0), max_delta)
+            return r.original_start + delta
+    return None
+
+
+def remap_words_to_original(
+    words: Optional[List[Dict[str, Any]]],
+    vad_ranges: Optional[Sequence[VadTimeRange]],
+) -> Optional[List[Dict[str, Any]]]:
+    """VAD後基準の単語タイムスタンプを元音声基準へ復元する。
+
+    stt-desktop の remap_word_timestamps_to_original と同等。復元できない
+    単語は元の値を保持する。区間情報がない場合はNone(復元不能)。
+    """
+    ranges = normalize_vad_ranges(vad_ranges)
+    if not ranges or not words:
+        return None
+
+    mapped: List[Dict[str, Any]] = []
+    for word in words:
+        copied = dict(word) if isinstance(word, dict) else word
+        if isinstance(copied, dict):
+            start_sec = _get_time_value(copied, _START_KEYS)
+            if start_sec is not None:
+                mapped_start = map_trimmed_to_original(start_sec, ranges)
+                if mapped_start is not None:
+                    _set_time_value(copied, _START_KEYS, mapped_start)
+            end_sec = _get_time_value(copied, _END_KEYS)
+            if end_sec is not None:
+                mapped_end = map_trimmed_to_original(end_sec, ranges)
+                if mapped_end is not None:
+                    _set_time_value(copied, _END_KEYS, mapped_end)
+        mapped.append(copied)
+    return mapped
+
+
+def build_word_timestamp_columns(
+    words: Optional[List[Dict[str, Any]]],
+    *,
+    vad_applied: bool,
+    vad_ranges: Optional[Sequence[VadTimeRange]] = None,
+) -> Tuple[Optional[List[Dict[str, Any]]], Optional[List[Dict[str, Any]]]]:
+    """保存用の (word_timestamps_json, word_timestamps_original_json) を作る。
+
+    - vad_applied=False: STT入力=元音声なので両カラムに同値を保存する。
+    - vad_applied=True: rawはそのまま、originalは保持区間から復元する。
+      区間情報が無く復元できない場合のみ original は None。
+    """
+    if not words:
+        return None, None
+    if not vad_applied:
+        return words, words
+    original = remap_words_to_original(words, vad_ranges)
+    if original is None:
+        logger.warning(
+            "VAD保持区間が無いため元音声基準のタイムスタンプを復元できませんでした"
+        )
+    return words, original

--- a/src/stt_wrapper.py
+++ b/src/stt_wrapper.py
@@ -1,8 +1,9 @@
 import os
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 import importlib.util
-from typing import Dict, Any, Optional
+from typing import Dict, Any, List, Optional
 from dotenv import load_dotenv
 
 # .envファイルを読み込む
@@ -10,6 +11,20 @@ load_dotenv()
 
 # スクリプトディレクトリをPythonパスに追加
 sys.path.append(str(Path(__file__).parent.parent / "scripts"))
+
+
+@dataclass
+class STTResult:
+    """文字起こし結果(単語タイムスタンプ付き)。
+
+    words は {text, start, end, type, speaker_id?} の配列(秒、STT入力音声基準)。
+    単語タイムスタンプ非対応のモデルでは None。
+    """
+
+    text: Optional[str]
+    words: Optional[List[Dict[str, Any]]] = None
+    error: Optional[str] = None
+
 
 class STTModelWrapper:
     """各STTモデルスクリプトを統一インターフェースで扱うラッパークラス"""
@@ -45,6 +60,28 @@ class STTModelWrapper:
             return result
         else:
             raise AttributeError(f"{self.module_name} does not have transcribe_audio_file function")
+
+    def transcribe_detailed(self, audio_file_path: str) -> STTResult:
+        """文字起こし+単語タイムスタンプ取得(対応モデルのみ)。
+
+        `transcribe_audio_file_detailed` を持つモジュール(現状 ElevenLabs)は
+        単語タイムスタンプ付きで返す。それ以外は従来の transcribe() の結果を
+        words=None で包む(後方互換)。
+        """
+        if hasattr(self.module, "transcribe_audio_file_detailed"):
+            detailed = self.module.transcribe_audio_file_detailed(audio_file_path)
+            if isinstance(detailed, dict):
+                return STTResult(
+                    text=detailed.get("text"),
+                    words=detailed.get("words") or None,
+                    error=detailed.get("error"),
+                )
+
+        result = self.transcribe(audio_file_path)
+        if isinstance(result, tuple) and result[0] is None:
+            error = result[1] if len(result) > 1 else "STT failed"
+            return STTResult(text=None, words=None, error=error)
+        return STTResult(text=result, words=None, error=None)
     
     @classmethod
     def get_available_models(cls) -> list:

--- a/src/ui/tabs/mic_tab.py
+++ b/src/ui/tabs/mic_tab.py
@@ -1,11 +1,11 @@
 import os
 import tempfile
-from datetime import datetime
 import streamlit as st
 
-from models import AudioTranscription, get_db
+from models import AudioTranscription, get_db, utcnow_naive
 from stt_wrapper import STTModelWrapper
 from text_structurer import TextStructurer
+from services.word_timestamps import build_word_timestamp_columns
 
 from pathlib import Path
 from services.audio_utils import (
@@ -84,7 +84,9 @@ def run_mic_tab(selected_model: str, use_structuring: bool, logger):
             duration = get_audio_duration(tmp_path)
         # ローカルへ永続保存（必要なら）
         final_path: str | None = None
-        timestamp = datetime.now()
+        # created_at・ファイル名ともnaive UTCで統一(本番サーバーはUTC。
+        # JSTマシンで動かしても日付判定(UTC解釈)とズレないようにする)
+        timestamp = utcnow_naive()
         file_extension = ".wav" if tmp_path.endswith('.wav') else ".webm"
         final_filename = f"mic_{timestamp.strftime('%Y%m%d_%H%M%S')}{file_extension}"
         if save_local:
@@ -112,12 +114,16 @@ def run_mic_tab(selected_model: str, use_structuring: bool, logger):
             use_vad = bool(getattr(app_settings, "get_use_vad", lambda: True)())
             vad_aggr = int(getattr(app_settings, "get_vad_aggressiveness", lambda: 2)())
             stt_input_path = tmp_path
+            vad_applied = False  # STT入力がVADトリム後音声か
+            vad_kept_ranges = None
             if use_vad:
                 try:
                     from services.vad import trim_non_speech
 
                     vad_res = trim_non_speech(tmp_path, enabled=True, aggressiveness=vad_aggr)
                     stt_input_path = vad_res.output_path
+                    vad_applied = True
+                    vad_kept_ranges = vad_res.kept_ranges
                     reduced = 0.0
                     if vad_res.orig_sec > 0:
                         reduced = max(0.0, 1.0 - (vad_res.out_sec / vad_res.orig_sec)) * 100.0
@@ -127,10 +133,10 @@ def run_mic_tab(selected_model: str, use_structuring: bool, logger):
                     logger.warning(f"VAD前処理に失敗したためスキップ: {e}")
                     st.warning("VAD前処理に失敗したため、元音声を使用します。")
 
-            transcription = stt_wrapper.transcribe(stt_input_path)
-            error_msg = None
-            if isinstance(transcription, tuple) and transcription[0] is None:
-                error_msg = transcription[1]
+            stt_result = stt_wrapper.transcribe_detailed(stt_input_path)
+            transcription = stt_result.text
+            error_msg = stt_result.error
+            if error_msg:
                 transcription = None
                 logger.error(f"マイク録音文字起こしエラー: {error_msg}")
 
@@ -191,6 +197,13 @@ def run_mic_tab(selected_model: str, use_structuring: bool, logger):
 
                 st.session_state.transcriptions.append(result)
 
+                # 単語タイムスタンプ(VAD後基準と元音声基準の両方)
+                word_ts, word_ts_original = build_word_timestamp_columns(
+                    stt_result.words,
+                    vad_applied=vad_applied,
+                    vad_ranges=vad_kept_ranges,
+                )
+
                 db = next(get_db())
                 try:
                     audio_record = AudioTranscription(
@@ -200,6 +213,8 @@ def run_mic_tab(selected_model: str, use_structuring: bool, logger):
                         transcript=transcription,
                         structured_json=structured_data,
                         tags=tags,
+                        word_timestamps_json=word_ts,
+                        word_timestamps_original_json=word_ts_original,
                     )
                     db.add(audio_record)
                     db.flush()

--- a/src/ui/tabs/rag_tab.py
+++ b/src/ui/tabs/rag_tab.py
@@ -17,6 +17,7 @@ from sqlalchemy import func, or_
 
 from models import RAGChatLog, USE_VECTOR, get_db
 from services.rag import highlight_date_in_query
+from services.rag.date_utils import jst_today
 from services.rag_service import get_rag_service
 
 logger = logging.getLogger(__name__)
@@ -426,6 +427,9 @@ def _run_chat(profile: _ChatProfile):
                 manual_date_range=manual_range,
                 chat_history=chat_history_for_rag,
                 previous_docs=previous_docs,
+                # サーバーはUTCのため、「今日」「昨日」等の判定と
+                # プロンプトの今日日付にはJSTの今日を明示的に渡す
+                today=jst_today(),
             )
         except Exception as e:
             _handle_rag_error(e, "検索実行")

--- a/src/ui/tabs/upload_tab.py
+++ b/src/ui/tabs/upload_tab.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from pathlib import Path
 import tempfile
 import os
@@ -6,11 +5,12 @@ import pandas as pd
 import streamlit as st
 import librosa
 
-from models import AudioTranscription, get_db
+from models import AudioTranscription, get_db, utcnow_naive
 from stt_wrapper import STTModelWrapper
 from text_structurer import TextStructurer
 from services.rag_service import get_rag_service
 from services.vad import trim_non_speech
+from services.word_timestamps import build_word_timestamp_columns
 
 
 def run_upload_tab(selected_model: str, use_structuring: bool, logger):
@@ -69,10 +69,14 @@ def run_upload_tab(selected_model: str, use_structuring: bool, logger):
                 vad_aggr = int(getattr(app_settings, "get_vad_aggressiveness", lambda: 2)())
                 stt_input_path = tmp_path
                 vad_note = None
+                vad_applied = False  # STT入力がVADトリム後音声か
+                vad_kept_ranges = None
                 if use_vad:
                     try:
                         vad_res = trim_non_speech(tmp_path, enabled=True, aggressiveness=vad_aggr)
                         stt_input_path = vad_res.output_path
+                        vad_applied = True
+                        vad_kept_ranges = vad_res.kept_ranges
                         reduced = 0.0
                         if vad_res.orig_sec > 0:
                             reduced = max(0.0, 1.0 - (vad_res.out_sec / vad_res.orig_sec)) * 100.0
@@ -83,13 +87,14 @@ def run_upload_tab(selected_model: str, use_structuring: bool, logger):
                         logger.warning(f"VAD前処理に失敗したためスキップ: {e}")
                         st.warning("VAD前処理に失敗したため、元音声を使用します。")
                         stt_input_path = tmp_path
+                        vad_applied = False
+                        vad_kept_ranges = None
 
                 logger.info(f"文字起こし実行中: {uploaded_file.name} (モデル: {selected_model})")
-                transcription = stt_wrapper.transcribe(stt_input_path)
-
-                error_msg = None
-                if isinstance(transcription, tuple) and transcription[0] is None:
-                    error_msg = transcription[1]
+                stt_result = stt_wrapper.transcribe_detailed(stt_input_path)
+                transcription = stt_result.text
+                error_msg = stt_result.error
+                if error_msg:
                     transcription = None
                     logger.error(f"文字起こしエラー: {error_msg}")
 
@@ -101,9 +106,19 @@ def run_upload_tab(selected_model: str, use_structuring: bool, logger):
                         if structured_data:
                             tags = text_structurer.extract_tags(structured_data)
 
+                    # 単語タイムスタンプ: STTが返したまま(VAD後基準)と、
+                    # VAD保持区間から元音声基準へ復元した値の両方を保存する
+                    word_ts, word_ts_original = build_word_timestamp_columns(
+                        stt_result.words,
+                        vad_applied=vad_applied,
+                        vad_ranges=vad_kept_ranges,
+                    )
+
+                    # created_atはnaive UTCで統一(desktop版と日付判定の互換のため)
+                    created_at = utcnow_naive()
                     result = {
                         "file_name": uploaded_file.name,
-                        "created_at": datetime.now(),
+                        "created_at": created_at,
                         "duration_seconds": duration,
                         "transcript": transcription,
                         "structured_json": structured_data,
@@ -116,11 +131,13 @@ def run_upload_tab(selected_model: str, use_structuring: bool, logger):
                     try:
                         audio_record = AudioTranscription(
                             file_path=uploaded_file.name,
-                            created_at=datetime.now(),
+                            created_at=created_at,
                             duration_seconds=duration,
                             transcript=transcription,
                             structured_json=structured_data,
                             tags=tags,
+                            word_timestamps_json=word_ts,
+                            word_timestamps_original_json=word_ts_original,
                         )
                         db.add(audio_record)
                         db.flush()

--- a/tests/test_chunk_timing.py
+++ b/tests/test_chunk_timing.py
@@ -1,0 +1,156 @@
+"""チャンクへの録音内時刻割り当て(chunk_timing)のテスト。"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pytest  # noqa: E402
+
+from services.rag.chunk_timing import (  # noqa: E402
+    assign_chunk_times,
+    parse_words_json,
+    select_timing_words,
+)
+from services.rag.chunker import chunk_text  # noqa: E402
+
+
+def _make_words(sentences, sec_per_char=0.5, gap=0.0):
+    """文のリストから1文字ずつの単語タイムスタンプを合成する。"""
+    words = []
+    t = 0.0
+    for s in sentences:
+        for ch in s:
+            words.append({"text": ch, "start": round(t, 3), "end": round(t + sec_per_char, 3), "type": "word"})
+            t += sec_per_char
+        t += gap
+    return words
+
+
+class TestParseWordsJson:
+    def test_json_string(self):
+        value = json.dumps([{"text": "あ", "start": 0.0, "end": 0.5}])
+        words = parse_words_json(value)
+        assert words and words[0]["text"] == "あ"
+
+    def test_list_passthrough(self):
+        words = parse_words_json([{"text": "あ"}])
+        assert words == [{"text": "あ"}]
+
+    def test_invalid_values(self):
+        assert parse_words_json(None) is None
+        assert parse_words_json("") is None
+        assert parse_words_json("not json") is None
+        assert parse_words_json("{}") is None
+        assert parse_words_json("[]") is None
+        assert parse_words_json([1, 2]) is None
+
+
+class TestSelectTimingWords:
+    RAW = json.dumps([{"text": "あ", "start": 0.0}])
+    ORIGINAL = json.dumps([{"text": "あ", "start": 10.0}])
+
+    def test_prefers_original(self):
+        words, basis = select_timing_words(self.RAW, self.ORIGINAL)
+        assert basis == "original"
+        assert words[0]["start"] == 10.0
+
+    def test_falls_back_to_raw_as_vad_basis(self):
+        words, basis = select_timing_words(self.RAW, None)
+        assert basis == "vad"
+        assert words[0]["start"] == 0.0
+
+    def test_none_when_neither(self):
+        assert select_timing_words(None, None) == (None, None)
+        assert select_timing_words("", "not json") == (None, None)
+
+
+class TestAssignChunkTimes:
+    def test_two_chunks_get_monotonic_ranges(self):
+        s1 = "最初の文です。" * 10  # 70文字
+        s2 = "次の文になります。" * 10  # 90文字
+        transcript = s1 + s2
+        chunks = list(chunk_text(transcript, chunk_size=80, chunk_overlap=0))
+        assert len(chunks) >= 2
+        words = _make_words([transcript], sec_per_char=0.1)
+        times = assign_chunk_times(transcript, chunks, words, chunk_overlap=0)
+        assert len(times) == len(chunks)
+        assert times[0][0] == pytest.approx(0.0)
+        # 各チャンクの時刻は単調に進む
+        for (s_prev, e_prev), (s_cur, e_cur) in zip(times, times[1:]):
+            assert s_cur >= s_prev
+            assert e_cur >= e_prev
+        # 最後のチャンクの終了は全体の長さ(160文字×0.1秒)にほぼ一致
+        assert times[-1][1] == pytest.approx(len(transcript) * 0.1, abs=0.2)
+
+    def test_overlap_chunks_are_located_correctly(self):
+        transcript = "".join(f"文{i}の内容はここ。" for i in range(40))  # 360文字
+        chunks = list(chunk_text(transcript, chunk_size=100, chunk_overlap=30))
+        words = _make_words([transcript], sec_per_char=0.2)
+        times = assign_chunk_times(transcript, chunks, words, chunk_overlap=30)
+        assert all(s is not None and e is not None for s, e in times)
+        # オーバーラップがあるため、次チャンクの開始は前チャンクの終了より手前
+        assert times[1][0] < times[0][1]
+        assert times[1][0] > times[0][0]
+
+    def test_whitespace_between_sentences_is_tolerated(self):
+        # チャンカーは文をstripして連結するため、本文に空白・改行があっても
+        # 正規化空間で対応付けできる
+        transcript = "こんにちは。\n 今日は晴れです。\nありがとう。"
+        chunks = list(chunk_text(transcript, chunk_size=12, chunk_overlap=0))
+        assert len(chunks) >= 2
+        words = _make_words(["こんにちは。", "今日は晴れです。", "ありがとう。"], sec_per_char=0.5)
+        times = assign_chunk_times(transcript, chunks, words)
+        assert times[0][0] == pytest.approx(0.0)
+        assert all(s is not None for s, _ in times)
+
+    def test_words_with_spacing_entries(self):
+        # ElevenLabsはtype=spacingの空白トークンを含む。正規化で無視される
+        transcript = "Hello world. Second sentence."
+        words = []
+        t = 0.0
+        for token in ["Hello", " ", "world.", " ", "Second", " ", "sentence."]:
+            entry = {"text": token, "start": round(t, 2), "end": round(t + 0.3, 2)}
+            entry["type"] = "spacing" if token == " " else "word"
+            words.append(entry)
+            t += 0.3
+        chunks = list(chunk_text(transcript, chunk_size=15, chunk_overlap=0))
+        times = assign_chunk_times(transcript, chunks, words)
+        assert times[0][0] == pytest.approx(0.0)
+        assert all(s is not None for s, _ in times)
+        # 2番目のチャンク("Second sentence.")は後半の単語時刻になる
+        assert times[-1][0] > times[0][0]
+
+    def test_scaling_when_transcript_differs_slightly(self):
+        # クレンジングでタグが除去され、本文と単語連結の長さがズレるケース
+        transcript = "本文はこれだけ。"  # 8文字
+        words = _make_words(["本文はこれだけ。(laughter)"], sec_per_char=1.0)
+        times = assign_chunk_times(transcript, [transcript], words)
+        s, e = times[0]
+        assert s == pytest.approx(0.0)
+        assert e is not None and e > 0
+
+    def test_unmatched_chunk_gets_none(self):
+        transcript = "実際の本文。"
+        words = _make_words([transcript], sec_per_char=0.5)
+        times = assign_chunk_times(transcript, ["存在しないチャンク"], words)
+        assert times == [(None, None)]
+
+    def test_no_words_or_empty(self):
+        assert assign_chunk_times("本文。", ["本文。"], None) == [(None, None)]
+        assert assign_chunk_times("本文。", ["本文。"], []) == [(None, None)]
+        assert assign_chunk_times("", ["本文。"], [{"text": "x", "start": 0}]) == [(None, None)]
+
+    def test_words_without_times_are_skipped(self):
+        transcript = "前半の文。後半の文。"
+        words = [
+            {"text": "前半の文。", "type": "word"},  # 時刻なし
+            {"text": "後半の文。", "start": 5.0, "end": 8.0, "type": "word"},
+        ]
+        chunks = ["前半の文。", "後半の文。"]
+        times = assign_chunk_times(transcript, chunks, words)
+        assert times[0] == (None, None)
+        assert times[1] == (pytest.approx(5.0), pytest.approx(8.0))

--- a/tests/test_index_chunk_times.py
+++ b/tests/test_index_chunk_times.py
@@ -1,0 +1,142 @@
+"""索引作成時のチャンク時刻付与(_index_generic)の統合テスト。
+
+本物のprod DB(Turso)には接続せず、in-memory SQLiteで検証する。
+埋め込みAPIはダミーに差し替える。
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pytest  # noqa: E402
+from sqlalchemy import text as sql_text  # noqa: E402
+
+from models import (  # noqa: E402
+    AudioTranscription,
+    AudioTranscriptionChunk,
+    RAG_FTS_TABLES,
+    SessionLocal,
+    engine,
+)
+from services.rag_service import RAGService  # noqa: E402
+
+
+TRANSCRIPT = "".join(f"作業{i}の記録がここにある。" for i in range(100))  # 1200文字 → 複数チャンク
+
+
+def _words_for(transcript, sec_per_char=0.5, offset=0.0):
+    return [
+        {"text": ch, "start": round(offset + i * sec_per_char, 3),
+         "end": round(offset + (i + 1) * sec_per_char, 3), "type": "word"}
+        for i, ch in enumerate(transcript)
+    ]
+
+
+@pytest.fixture()
+def db():
+    # FTS5仮想テーブル(libsql環境でのみ自動作成)をテスト用に用意する
+    try:
+        with engine.begin() as conn:
+            for fts in RAG_FTS_TABLES.values():
+                conn.execute(
+                    sql_text(
+                        f"CREATE VIRTUAL TABLE IF NOT EXISTS {fts} "
+                        "USING fts5(tokens, tokenize='unicode61')"
+                    )
+                )
+    except Exception as exc:  # pragma: no cover - FTS5非対応のsqlite
+        pytest.skip(f"FTS5が利用できないためスキップ: {exc}")
+    session = SessionLocal()
+    yield session
+    session.rollback()
+    session.close()
+
+
+@pytest.fixture()
+def rag(monkeypatch):
+    service = RAGService()
+    # in-memory SQLite + APIキーなしでも索引処理を通す
+    service._enabled = True
+    monkeypatch.setattr(
+        service, "_embed_texts", lambda texts: [[0.0, 0.0] for _ in texts]
+    )
+    return service
+
+
+def _insert_recording(db, *, raw_json=None, original_json=None) -> int:
+    record = AudioTranscription(
+        file_path="rec.mp3",
+        duration_seconds=600.0,
+        transcript=TRANSCRIPT,
+        word_timestamps_json=raw_json,
+        word_timestamps_original_json=original_json,
+    )
+    db.add(record)
+    db.flush()
+    return record.id
+
+
+class TestIndexChunkTimes:
+    def test_original_words_used_with_original_basis(self, db, rag):
+        words_vad = _words_for(TRANSCRIPT, sec_per_char=0.4)
+        words_original = _words_for(TRANSCRIPT, sec_per_char=0.4, offset=120.0)
+        tid = _insert_recording(db, raw_json=words_vad, original_json=words_original)
+
+        assert rag._index_generic(db, "audio", tid, TRANSCRIPT)
+        chunks = (
+            db.query(AudioTranscriptionChunk)
+            .filter_by(transcription_id=tid)
+            .order_by(AudioTranscriptionChunk.chunk_index)
+            .all()
+        )
+        assert len(chunks) >= 2
+        assert all(c.time_basis == "original" for c in chunks)
+        # originalはoffset=120秒から始まる時刻系
+        assert chunks[0].start_sec == pytest.approx(120.0, abs=1.0)
+        assert chunks[-1].end_sec > chunks[0].start_sec
+        for prev, cur in zip(chunks, chunks[1:]):
+            assert cur.start_sec >= prev.start_sec
+
+    def test_desktop_row_with_raw_only_gets_vad_basis(self, db, rag):
+        # デスクトップ保存分: word_timestamps_json のみ(JSON文字列)のケース
+        words = _words_for(TRANSCRIPT, sec_per_char=0.3)
+        tid = _insert_recording(db, raw_json=None, original_json=None)
+        db.execute(
+            sql_text(
+                "UPDATE audio_transcriptions SET word_timestamps_json = :w WHERE id = :id"
+            ),
+            {"w": json.dumps(words, ensure_ascii=False), "id": tid},
+        )
+
+        assert rag._index_generic(db, "audio", tid, TRANSCRIPT)
+        chunks = (
+            db.query(AudioTranscriptionChunk)
+            .filter_by(transcription_id=tid)
+            .order_by(AudioTranscriptionChunk.chunk_index)
+            .all()
+        )
+        assert all(c.time_basis == "vad" for c in chunks)
+        assert chunks[0].start_sec == pytest.approx(0.0, abs=0.5)
+
+    def test_row_without_words_keeps_null_times(self, db, rag):
+        tid = _insert_recording(db)
+        assert rag._index_generic(db, "audio", tid, TRANSCRIPT)
+        chunks = db.query(AudioTranscriptionChunk).filter_by(transcription_id=tid).all()
+        assert chunks
+        assert all(c.start_sec is None and c.end_sec is None for c in chunks)
+        assert all(c.time_basis is None for c in chunks)
+
+    def test_reindex_replaces_chunks_and_times(self, db, rag):
+        tid = _insert_recording(db, original_json=_words_for(TRANSCRIPT, sec_per_char=0.2))
+        assert rag._index_generic(db, "audio", tid, TRANSCRIPT)
+        first_count = db.query(AudioTranscriptionChunk).filter_by(transcription_id=tid).count()
+        # 再索引しても二重登録されない(reconcileの再実行相当)
+        assert rag._index_generic(db, "audio", tid, TRANSCRIPT)
+        chunks = db.query(AudioTranscriptionChunk).filter_by(transcription_id=tid).all()
+        assert len(chunks) == first_count
+        assert len({c.chunk_index for c in chunks}) == len(chunks)
+        assert all(c.time_basis == "original" for c in chunks)

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -1,0 +1,72 @@
+"""プロンプト組み立て(録音内時刻・VAD基準注記)のテスト。"""
+
+import os
+import sys
+from datetime import date
+from pathlib import Path
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from services.rag.context_builder import ContextDoc  # noqa: E402
+from services.rag import prompt_builder  # noqa: E402
+from services.rag.prompt_builder import (  # noqa: E402
+    build_chat_messages,
+    build_system_prompt,
+    format_context_block,
+)
+
+
+def _doc(n=1, time_basis=None, text="本文です。"):
+    return ContextDoc(
+        n=n,
+        source="audio",
+        transcription_id=n,
+        title=f"rec{n}.mp3",
+        recorded_date="2026-08-01",
+        tags=None,
+        text=text,
+        score=0.9,
+        hit_count=1,
+        is_full_text=True,
+        truncated=False,
+        time_basis=time_basis,
+    )
+
+
+class TestSystemPrompt:
+    def test_includes_mmss_rule(self):
+        prompt = build_system_prompt(today=date(2026, 8, 11))
+        assert "MM:SS" in prompt
+        assert "録音開始からの経過時間" in prompt
+
+    def test_today_fallback_uses_jst(self, monkeypatch):
+        monkeypatch.setattr(prompt_builder, "jst_today", lambda: date(2026, 8, 11))
+        assert "今日の日付: 2026-08-11" in build_system_prompt()
+
+    def test_explicit_today(self):
+        assert "今日の日付: 2026-07-31" in build_system_prompt(today=date(2026, 7, 31))
+
+
+class TestVadBasisNote:
+    def test_vad_basis_doc_gets_note(self):
+        block = format_context_block([_doc(time_basis="vad")])
+        assert "無音カット(VAD)後の音声基準" in block
+        assert "ズレている可能性" in block
+
+    def test_original_basis_doc_has_no_note(self):
+        block = format_context_block([_doc(time_basis="original")])
+        assert "無音カット" not in block
+
+    def test_untimed_doc_has_no_note(self):
+        block = format_context_block([_doc(time_basis=None)])
+        assert "無音カット" not in block
+
+    def test_chat_messages_carry_note(self):
+        messages = build_chat_messages(
+            "いつ話した？", [_doc(time_basis="vad", text="[00:10〜00:20] 発言。")],
+            today=date(2026, 8, 11),
+        )
+        user_msg = messages[-1]["content"]
+        assert "[00:10〜00:20] 発言。" in user_msg
+        assert "無音カット(VAD)後の音声基準" in user_msg

--- a/tests/test_rag_context_and_blend.py
+++ b/tests/test_rag_context_and_blend.py
@@ -72,16 +72,44 @@ def mini_db():
         ))
         c.execute(text(
             "CREATE TABLE audio_transcription_chunks ("
-            "id INTEGER PRIMARY KEY, transcription_id INTEGER, chunk_index INTEGER, chunk_text TEXT)"
+            "id INTEGER PRIMARY KEY, transcription_id INTEGER, chunk_index INTEGER, chunk_text TEXT, "
+            "start_sec REAL, end_sec REAL, time_basis TEXT)"
         ))
         c.execute(text("INSERT INTO audio_transcriptions VALUES (1, '短い録音の全文です。')"))
         long_text = "長い録音。" * 2000  # 10000文字
         c.execute(text("INSERT INTO audio_transcriptions VALUES (2, :t)"), {"t": long_text})
         for i in range(5):
             c.execute(
-                text("INSERT INTO audio_transcription_chunks VALUES (:id, 2, :idx, :t)"),
+                text(
+                    "INSERT INTO audio_transcription_chunks VALUES "
+                    "(:id, 2, :idx, :t, NULL, NULL, NULL)"
+                ),
                 {"id": 100 + i, "idx": i, "t": f"チャンク{i}の本文。" * 10},
             )
+        # id=3: 時刻付きチャンクを持つ長い録音(タイムスタンプ表示のテスト用)
+        c.execute(text("INSERT INTO audio_transcriptions VALUES (3, :t)"), {"t": "時刻付き。" * 1000})
+        for i in range(5):
+            c.execute(
+                text(
+                    "INSERT INTO audio_transcription_chunks VALUES "
+                    "(:id, 3, :idx, :t, :s, :e, 'original')"
+                ),
+                {
+                    "id": 200 + i,
+                    "idx": i,
+                    "t": f"時刻チャンク{i}の本文。" * 10,
+                    "s": i * 60.0,
+                    "e": i * 60.0 + 55.0,
+                },
+            )
+        # id=4: 時刻付きチャンクを持つ短い録音(全文表示でも時刻ラベルが付く)
+        c.execute(text("INSERT INTO audio_transcriptions VALUES (4, '短い時刻付き録音です。続きの文です。')"))
+        c.execute(
+            text(
+                "INSERT INTO audio_transcription_chunks VALUES "
+                "(300, 4, 0, '短い時刻付き録音です。続きの文です。', 12.0, 34.0, 'vad')"
+            )
+        )
     Session = sessionmaker(bind=engine)
     db = Session()
     yield db
@@ -171,6 +199,64 @@ class TestNormalizeToJstDate:
         assert normalize_to_jst_date(None) is None
         assert normalize_to_jst_date("") is None
         assert normalize_to_jst_date("not a date") is None
+
+
+class TestTimedContext:
+    """チャンク時刻(start_sec/end_sec)がある録音の [MM:SS〜MM:SS] 表示。"""
+
+    def test_format_mmss(self):
+        from services.rag.context_builder import _format_mmss
+
+        assert _format_mmss(0) == "00:00"
+        assert _format_mmss(75.4) == "01:15"
+        assert _format_mmss(3900) == "65:00"  # 60分超は分が2桁を超える
+
+    def test_excerpt_windows_have_time_labels(self, mini_db):
+        docs = build_context_docs(
+            mini_db, [_hit(3, 2, 0.8)], max_docs=3, max_chars=40000, whole_doc_threshold=4000
+        )
+        assert len(docs) == 1
+        d = docs[0]
+        assert not d.is_full_text
+        assert d.time_basis == "original"
+        # ヒット±1のチャンク(1,2,3)が時刻ラベル付きで含まれる
+        assert "[01:00〜01:55] 時刻チャンク1の本文。" in d.text
+        assert "[02:00〜02:55]" in d.text
+        assert "[00:00〜00:55]" not in d.text  # window外
+        assert "[04:00〜04:55]" not in d.text  # window外
+
+    def test_full_text_gets_time_labels(self, mini_db):
+        docs = build_context_docs(
+            mini_db, [_hit(4, 0, 0.9)], max_docs=3, max_chars=40000, whole_doc_threshold=4000
+        )
+        assert len(docs) == 1
+        d = docs[0]
+        assert d.is_full_text
+        assert d.time_basis == "vad"
+        assert d.text.startswith("[00:12〜00:34] 短い時刻付き録音です。")
+
+    def test_untimed_doc_unchanged(self, mini_db):
+        docs = build_context_docs(
+            mini_db, [_hit(2, 2, 0.8)], max_docs=3, max_chars=40000, whole_doc_threshold=4000
+        )
+        assert docs[0].time_basis is None
+        assert "[0" not in docs[0].text  # 時刻ラベルなし
+
+    def test_merge_timed_windows_overlap_and_gap(self):
+        from services.rag.context_builder import _ChunkRow, _merge_timed_chunk_windows
+
+        rows = [
+            _ChunkRow(0, "あいうえおかきくけこ", 0.0, 10.0, "original"),
+            _ChunkRow(1, "かきくけこさしすせそ", 5.0, 15.0, "original"),  # 前半5文字が重複
+            _ChunkRow(3, "離れたチャンク", 30.0, 40.0, "original"),
+        ]
+        out = _merge_timed_chunk_windows(rows, {0, 1, 3})
+        lines = out.split("\n")
+        assert lines[0] == "[00:00〜00:10] あいうえおかきくけこ"
+        # 重複5/10文字を除去し、開始時刻は線形補間で 5.0 + 10*0.5 = 10.0
+        assert lines[1] == "[00:10〜00:15] さしすせそ"
+        assert lines[2] == "（…中略…）"
+        assert lines[3] == "[00:30〜00:40] 離れたチャンク"
 
 
 class TestPerDocCap:

--- a/tests/test_timezone_writes.py
+++ b/tests/test_timezone_writes.py
@@ -1,0 +1,83 @@
+"""タイムゾーン扱い(created_at書き込み・JSTの今日)のテスト。"""
+
+import os
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pytest  # noqa: E402
+
+from models import AudioTranscription, CeoTranscription, utcnow_naive  # noqa: E402
+from services.rag import date_utils  # noqa: E402
+from services.rag.date_utils import jst_today, parse_date_from_query  # noqa: E402
+from services.rag.reconcile import JST, normalize_to_jst_date  # noqa: E402
+
+
+class _FakeDatetime:
+    """JSTでは翌日になっているUTC夕方の時刻に固定する。"""
+
+    fixed = datetime(2026, 8, 10, 16, 30, tzinfo=timezone.utc)  # JST: 2026-08-11 01:30
+
+    @classmethod
+    def now(cls, tz=None):
+        if tz is None:
+            return cls.fixed.replace(tzinfo=None)
+        return cls.fixed.astimezone(tz)
+
+
+class TestUtcnowNaive:
+    def test_returns_naive_utc(self):
+        value = utcnow_naive()
+        assert value.tzinfo is None
+        delta = abs((value - datetime.now(timezone.utc).replace(tzinfo=None)).total_seconds())
+        assert delta < 5.0
+
+    def test_model_defaults_use_utcnow_naive(self):
+        # bare datetime.now(サーバーローカル依存)に戻っていないことを担保する
+        # (SQLAlchemyは引数なしのdefault関数をラップするため__wrapped__を見る)
+        def default_fn(column):
+            arg = column.default.arg
+            return getattr(arg, "__wrapped__", arg)
+
+        assert default_fn(AudioTranscription.__table__.c.created_at) is utcnow_naive
+        assert default_fn(CeoTranscription.__table__.c.created_at) is utcnow_naive
+
+    def test_written_value_reconciles_to_jst_date(self):
+        # naive UTCとして書いた値は、日付判定(UTC解釈+9h)でJSTの日付になる
+        value = datetime(2026, 8, 10, 16, 30)  # naive UTC
+        assert normalize_to_jst_date(value) == "2026-08-11"
+
+
+class TestJstToday:
+    def test_jst_today_rolls_forward_at_utc_evening(self, monkeypatch):
+        monkeypatch.setattr(date_utils, "datetime", _FakeDatetime)
+        assert jst_today() == date(2026, 8, 11)
+
+    def test_parse_date_fallback_uses_jst_today(self, monkeypatch):
+        monkeypatch.setattr(date_utils, "datetime", _FakeDatetime)
+        dr = parse_date_from_query("今日の作業")  # today指定なし
+        assert (dr.start, dr.end) == (date(2026, 8, 11), date(2026, 8, 11))
+
+    def test_jst_constant(self):
+        assert JST.utcoffset(None).total_seconds() == 9 * 3600
+
+
+class TestExplicitTodayStillWins:
+    def test_passed_today_overrides_fallback(self, monkeypatch):
+        monkeypatch.setattr(date_utils, "datetime", _FakeDatetime)
+        dr = parse_date_from_query("昨日の記録", today=date(2026, 7, 31))
+        assert dr.start == date(2026, 7, 30)
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("2026-08-10 16:30:00.123456", "2026-08-11"),  # Web版naive UTC
+        ("2026-08-10T16:30:00.906558100+00:00", "2026-08-11"),  # desktop RFC3339
+    ],
+)
+def test_both_writer_formats_agree(raw, expected):
+    assert normalize_to_jst_date(raw) == expected

--- a/tests/test_word_timestamps.py
+++ b/tests/test_word_timestamps.py
@@ -1,0 +1,156 @@
+"""VAD保持区間と単語タイムスタンプ復元(remap)のテスト。"""
+
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+from services.vad import VadTimeRange, _energy_trim, _identity_ranges  # noqa: E402
+from services.word_timestamps import (  # noqa: E402
+    build_word_timestamp_columns,
+    map_trimmed_to_original,
+    normalize_vad_ranges,
+    remap_words_to_original,
+)
+
+
+def _ranges():
+    """元音声0-10秒のうち [1,3] と [6,8] を保持した場合の区間。"""
+    return [
+        VadTimeRange(original_start=1.0, original_end=3.0, trimmed_start=0.0, trimmed_end=2.0),
+        VadTimeRange(original_start=6.0, original_end=8.0, trimmed_start=2.0, trimmed_end=4.0),
+    ]
+
+
+class TestMapTrimmedToOriginal:
+    def test_first_range(self):
+        assert map_trimmed_to_original(0.5, _ranges()) == pytest.approx(1.5)
+
+    def test_second_range_with_gap_restored(self):
+        # トリム後2.5秒 = 2番目の保持区間の0.5秒目 → 元音声6.5秒
+        assert map_trimmed_to_original(2.5, _ranges()) == pytest.approx(6.5)
+
+    def test_boundary_maps_to_previous_range_end(self):
+        # 区間境界(2.0)は前の区間の終端として扱う(desktopの許容誤差1e-6と同じ挙動)
+        assert map_trimmed_to_original(2.0, _ranges()) == pytest.approx(3.0)
+
+    def test_last_range_end_inclusive(self):
+        assert map_trimmed_to_original(4.0, _ranges()) == pytest.approx(8.0)
+
+    def test_out_of_range_returns_none(self):
+        assert map_trimmed_to_original(5.0, _ranges()) is None
+        assert map_trimmed_to_original(-1.0, _ranges()) is None
+
+    def test_empty_ranges(self):
+        assert map_trimmed_to_original(1.0, []) is None
+
+
+class TestNormalizeVadRanges:
+    def test_filters_invalid_and_sorts(self):
+        ranges = [
+            VadTimeRange(6.0, 8.0, 2.0, 4.0),
+            VadTimeRange(1.0, 1.0, 0.0, 2.0),  # original幅ゼロ → 除外
+            VadTimeRange(1.0, 3.0, 0.0, 2.0),
+            VadTimeRange(float("nan"), 3.0, 0.0, 2.0),  # 非有限 → 除外
+        ]
+        out = normalize_vad_ranges(ranges)
+        assert [(r.trimmed_start, r.trimmed_end) for r in out] == [(0.0, 2.0), (2.0, 4.0)]
+
+    def test_none_and_empty(self):
+        assert normalize_vad_ranges(None) == []
+        assert normalize_vad_ranges([]) == []
+
+
+class TestRemapWordsToOriginal:
+    def test_remaps_start_and_end(self):
+        words = [
+            {"text": "こんにちは", "start": 0.2, "end": 1.0, "type": "word"},
+            {"text": "世界", "start": 2.2, "end": 3.8, "type": "word"},
+        ]
+        out = remap_words_to_original(words, _ranges())
+        assert out is not None
+        assert out[0]["start"] == pytest.approx(1.2)
+        assert out[0]["end"] == pytest.approx(2.0)
+        assert out[1]["start"] == pytest.approx(6.2)
+        assert out[1]["end"] == pytest.approx(7.8)
+        # 入力は破壊しない
+        assert words[0]["start"] == 0.2
+
+    def test_unmappable_word_keeps_value(self):
+        words = [{"text": "外", "start": 9.9, "end": 9.95}]
+        out = remap_words_to_original(words, _ranges())
+        assert out[0]["start"] == 9.9
+
+    def test_no_ranges_returns_none(self):
+        assert remap_words_to_original([{"text": "a", "start": 0.0}], None) is None
+        assert remap_words_to_original([{"text": "a", "start": 0.0}], []) is None
+
+    def test_alias_keys(self):
+        words = [{"text": "a", "start_time": 0.5, "end_time": 1.5}]
+        out = remap_words_to_original(words, _ranges())
+        assert out[0]["start_time"] == pytest.approx(1.5)
+        assert out[0]["end_time"] == pytest.approx(2.5)
+
+
+class TestBuildWordTimestampColumns:
+    WORDS = [{"text": "テスト", "start": 0.5, "end": 1.0, "type": "word"}]
+
+    def test_no_words(self):
+        assert build_word_timestamp_columns(None, vad_applied=True) == (None, None)
+        assert build_word_timestamp_columns([], vad_applied=False) == (None, None)
+
+    def test_without_vad_both_columns_equal(self):
+        raw, original = build_word_timestamp_columns(self.WORDS, vad_applied=False)
+        assert raw == self.WORDS
+        assert original == self.WORDS
+
+    def test_with_vad_original_is_remapped(self):
+        raw, original = build_word_timestamp_columns(
+            self.WORDS, vad_applied=True, vad_ranges=_ranges()
+        )
+        assert raw[0]["start"] == 0.5  # VAD後基準はそのまま
+        assert original[0]["start"] == pytest.approx(1.5)  # 元音声基準へ復元
+
+    def test_with_vad_but_no_ranges(self):
+        raw, original = build_word_timestamp_columns(
+            self.WORDS, vad_applied=True, vad_ranges=None
+        )
+        assert raw == self.WORDS
+        assert original is None
+
+
+class TestVadKeptRanges:
+    def test_identity_ranges(self):
+        rs = _identity_ranges(12.5)
+        assert len(rs) == 1
+        assert (rs[0].original_start, rs[0].original_end) == (0.0, 12.5)
+        assert (rs[0].trimmed_start, rs[0].trimmed_end) == (0.0, 12.5)
+        assert _identity_ranges(0.0) == []
+
+    def test_energy_trim_returns_consistent_ranges(self):
+        sr = 16000
+        # 1秒音声 + 2秒無音 + 1秒音声
+        t = np.linspace(0, 1, sr, endpoint=False)
+        tone = 0.5 * np.sin(2 * np.pi * 440 * t)
+        audio = np.concatenate([tone, np.zeros(2 * sr), tone]).astype(np.float32)
+
+        trimmed, out_sec, ranges = _energy_trim(audio, sr, top_db=30, pad_ms=0)
+        assert out_sec < 4.0  # 無音がカットされている
+        assert len(ranges) == 2
+        # トリム後タイムラインは連続しており、合計が出力長と一致する
+        assert ranges[0].trimmed_start == pytest.approx(0.0)
+        for prev, cur in zip(ranges, ranges[1:]):
+            assert cur.trimmed_start == pytest.approx(prev.trimmed_end)
+        assert ranges[-1].trimmed_end == pytest.approx(out_sec, abs=1e-6)
+        # 2番目の保持区間は元音声の3秒付近から始まる
+        assert ranges[1].original_start == pytest.approx(3.0, abs=0.2)
+        # 対応付け: トリム後の2番目区間の中央 → 元音声の対応時刻
+        mid = (ranges[1].trimmed_start + ranges[1].trimmed_end) / 2
+        mapped = map_trimmed_to_original(mid, ranges)
+        expected = ranges[1].original_start + (mid - ranges[1].trimmed_start)
+        assert mapped == pytest.approx(expected)


### PR DESCRIPTION
## 概要

課題管理表 **課題198「発言単位タイムスタンプの保存とRAGでの利用」** の実装と、既知のタイムゾーンバグ2件の修正です。

- ElevenLabsの単語タイムスタンプを全保存経路(アップロード / マイク録音 / CEO処理)で保存
- VAD(無音カット)後のタイムスタンプを元音声基準へ復元して両方保存(stt-desktopと同スキーマ・同ロジック)
- RAGのチャンクに録音内時刻を割り当て、QA回答時に `[MM:SS〜MM:SS]` で発言時刻を提示
- created_atのTZ解釈矛盾と「今日」判定のJST非対応を修正

## 実装内容

### 1. 発言単位タイムスタンプの保存

- `scripts/transcribe_elevenlabs.py`: `transcribe_audio_file_detailed()` を追加し、`result.words` から `{text, start, end, type, speaker_id?}` を取得(従来の `transcribe_audio_file()` は互換維持)。`characters`・`logprob` はサイズ削減のため保存しません
- `src/stt_wrapper.py`: `STTResult` と `transcribe_detailed()` を追加。単語タイムスタンプ非対応のエンジン(ElevenLabs以外)は `words=None` で従来動作
- `src/services/vad.py`: `trim_non_speech()` が保持区間 `kept_ranges`(元音声時刻⇔トリム後時刻の対応 `VadTimeRange`)を返すよう拡張。トリムなし・各フォールバック経路では恒等区間を返します
- `src/services/word_timestamps.py`(新規): stt-desktop の `remap_word_timestamps_to_original`(`src-tauri/src/transcript.rs`)と同等のロジックで、VAD後基準のタイムスタンプを元音声基準へ復元
- 保存経路(`upload_tab` / `mic_tab` / `ceo_processor`)すべてで、`word_timestamps_json`(STTが返したまま=VAD後基準)と `word_timestamps_original_json`(元音声基準へ復元)の**両方**を保存。VADを通らなかった場合は同値を両カラムに保存します
  - 注: 事前調査と異なり、アップロード・マイク録音もVADを通す実装だったため(`upload_tab.py:72-85` / `mic_tab.py:115-129`)、audio側にも復元処理を適用しています

### 2. RAGでの利用

- `src/services/rag/chunk_timing.py`(新規): チャンクと単語タイムスタンプを「空白除去した正規化空間」の文字位置で対応付け、各チャンクに開始・終了時刻を割り当て(近似)。繰り返しの多い本文でも誤マッチしないよう、探索開始位置をオーバーラップ幅で制限
- `_index_generic`(索引作成)で時刻を割り当て。**`word_timestamps_original_json`(元音声基準)を優先**し、無い行のみ `word_timestamps_json`(VAD後基準)にフォールバック。どちらを使ったかは `time_basis`(`original` / `vad`)としてチャンクに記録
- デスクトップ版保存分も `reconcile`(再同期)経由の索引時に時刻が付きます。既存チャンク(時刻なし)はNULLのまま従来動作
- コンテキスト(`context_builder`)で、時刻が取れているチャンクに `[MM:SS〜MM:SS]` を表示(全文表示の録音にも付与)。システムプロンプトに「発言時刻はMM:SS形式で明示する」ルールを追加
- **VAD後基準の時刻しか無い録音**(original無しの既存データ等)には「録音内時刻は無音カット(VAD)後の音声基準のため、元の録音の再生位置とはズレている可能性がある」注記をコンテキストヘッダに付与。original基準が使えている場合は注記なし
- 検索側のソース定義(`search_service.py` の `_SOURCES`、`rag_tab.py` の `_SOURCE_LABELS`、ソース選択UI)は変更していません(課題199で使用予定)

### 3. タイムゾーンバグ修正

- **created_atのTZ解釈矛盾**: 書き込み側の bare `datetime.now()`(サーバーローカル依存)を `models.utcnow_naive()`(naive UTC)に統一。日付判定(`normalize_to_jst_date` のnaive=UTC解釈)・デスクトップ版(RFC3339 UTC)と整合し、JSTマシンで動かしてもズレません。`models.py:84` の誤コメント「naive JST」→「naive UTC」も修正(aware値はSQLiteの文字列形式が変わるためnaiveのまま)
- **「今日」のJST非対応**: `rag_tab` が `answer_stream(today=jst_today())` を明示的に渡すよう修正。`parse_date_from_query` / `build_system_prompt` のフォールバックもJSTの今日に変更(UTCサーバーでJST 0〜9時に「今日」「昨日」が1日ズレる問題)

## スキーマ変更(`_ensure_columns` による冪等なALTER TABLE)

| テーブル | 追加カラム | 備考 |
|---|---|---|
| `audio_transcriptions` | `word_timestamps_json` TEXT, `word_timestamps_original_json` TEXT | desktop作成済みDBでは既存のためスキップ |
| `ceo_transcriptions` | `word_timestamps_json` TEXT, `word_timestamps_original_json` TEXT | 新規追加(desktop側は別作業で追加予定) |
| `audio_transcription_chunks` | `start_sec` REAL, `end_sec` REAL, `time_basis` TEXT | NULL=時刻なし(既存チャンクは従来動作) |
| `ceo_transcription_chunks` | `start_sec` REAL, `end_sec` REAL, `time_basis` TEXT | 同上 |

- カラム名・形式(単語オブジェクト配列のJSON)は stt-desktop(`src-tauri/src/db.rs` / `DbView.tsx` の `extractWordTimestamps`)と互換
- ORMでは `word_timestamps_*` を `deferred` にしており、DB一覧タブ等の全件読み込みで巨大JSONを読まない
- JSON列の書き込みを `ensure_ascii=False`・コンパクト形式に変更(日本語の\uXXXXエスケープによるサイズ肥大を回避。desktopのserde_jsonと同方針)

## 動作確認方法

1. `uv run python -m pytest tests/` → **169件全通過**(新規: remap/VAD保持区間、チャンク時刻割当、索引統合、プロンプト、TZ処理)
2. 本物のprod DBに接続しないため、DBを伴う検証はin-memory SQLite+旧スキーマDBへのALTER TABLEシミュレーションで実施(冪等性・既存行維持を確認済み)
3. デプロイ後の確認手順:
   - アップロード or マイク録音(ElevenLabs)で保存 → DBの `word_timestamps_json` / `word_timestamps_original_json` に単語配列が入ること
   - CEO処理(VADあり)で保存 → 両カラムの時刻がVADカット分だけずれて復元されていること
   - QAタブで再索引後、「〜はいつ頃話していた?」等に `MM:SS` 形式の時刻つきで回答されること
   - デスクトップ版で保存した録音(words あり)を再索引 → 時刻が付き、original無しの場合は回答コンテキストにVAD基準の注記が付くこと

## 実装上の判断・調査時情報との差異

- **調査時情報との差異**: 「audio側(upload/mic)はVADを通さない」とありましたが、実際は両タブともVADを通すため(現物確認)、全経路にVAD復元を実装しました
- 単語タイムスタンプの `logprob` / `characters` は保存対象外(desktopのビューア `extractWordTimestamps` はこれらが無くても動作することを確認済み)
- チャンク⇔時刻の対応付けは文字位置ベースの近似です(チャンカーが文をstripして連結するため、空白除去した正規化空間では完全一致)。本文と単語連結がクレンジング差分でズレる場合は比例スケーリングで近似
- `ceo_tab.py` の `recorded_at` 既定値(bare `datetime.now().isoformat()`)は今回のスコープ外として未変更です(本番サーバーはUTCのため実害なし。表示仕様に関わるため別途検討)

課題199(RAG独立ソース追加)はこのブランチをベースに実装予定です。
