### PR TITLE
RAG検索ソースに「業務記録」を追加し、QAチャットを1タブ+ソース選択pillsに統合（課題199）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,13 +185,13 @@ uv lock --upgrade
 - RAG機能は Turso(libSQL) 専用です（Postgres対応は削除）。
 - `.env` では必須の `OPENAI_API_KEY` に加え、必要に応じて `EMBEDDING_MODEL` (既定: text-embedding-3-large、dimensions=1536で格納), `EMBEDDING_DIM`, `RAG_COMPLETION_MODEL`, `ENABLE_RAG` を設定可能。
 - 新規保存分は自動でチャンク化・埋め込み登録。既存データをRAG対応させるには再保存やバックフィルスクリプトが必要。
-- Streamlit UIのQAチャットは「💬 現場録音に質問」「💬 社長音声に質問」の2タブに分離（検索エンジンは共通、検索対象・会話履歴・プロンプトが別）。
+- Streamlit UIのQAチャットは「💬 録音データに質問」の1タブ。検索対象はソース選択pills（現場録音/社長音声/業務記録、既定は全ソース）で切り替える。
 - Supabase関連の機能（Storage・移行ドキュメント等）は削除済みです。
 
 ## Agent Notes（RAG開発向けメモ）
 - 本リポジトリはデータベースをTurso(libSQL)に完全移行済み。Postgres/pgvector対応はコードから削除済みです。関連依存（psycopg2, pgvector）も`pyproject.toml`から除外しました。
-- QAチャット（「現場録音に質問」「社長音声に質問」タブ）のアーキテクチャ:
-  - 出口は現場録音用と社長音声用で分離（`ui/tabs/rag_tab.py`の`_ChatProfile`）。会話ログは`rag_chat_logs.chat_kind`（"audio"/"ceo"、NULLは旧データ=audio扱い）で区別
+- QAチャット（「録音データに質問」タブ）のアーキテクチャ:
+  - 出口は1タブ（`ui/tabs/rag_tab.py`）で、検索対象はソース選択pills（audio/ceo/work、既定は全ソース）。会話ログ`rag_chat_logs.chat_kind`はデスクトップ版と同じ規則で記録（現場録音を含む検索="audio" / 含まない="ceo"、NULLは旧データ=audio扱い。参照ソースは`contexts[].source`に残る）
   - 新規保存分は保存時に即時索引化（現場録音: upload_tab/mic_tab、社長音声: ceo_processor）。デスクトップ版等の外部保存分はQAタブ表示時に自動取り込み（20件以下は自動、超過時はボタン表示）
   - 検索モードは3種: `search`（ハイブリッド検索）/ `browse`（期間・要約だけが手がかりの質問。新しい順に最大`RAG_AGGREGATE_MAX_DOCS`=30件を薄く読む）/ `followup`（形式変更・メタ質問。再検索せず前回の参照録音を再利用）
   - `services/rag/query_cleaner.py`: 検索計画の判断材料（指示語除去・内容語判定・集約/追問判定・STT表記ゆれ同義語辞書）。同義語はprodコーパス走査で実在確認したもののみ登録（ヒケ=引け、ソリ=反り等）。指示語バイグラムはBM25を汚染するためFTSクエリから除外する（実測nDCG@6 0.47→0.64）

--- a/scripts/backfill_rag.py
+++ b/scripts/backfill_rag.py
@@ -35,7 +35,10 @@ def main() -> None:
     try:
         if args.dry_run:
             pending = rag.pending_counts(db)
-            print(f"未インデックス: 現場録音 {pending.get('audio', 0)}件 / 社長音声 {pending.get('ceo', 0)}件")
+            print(
+                f"未インデックス: 現場録音 {pending.get('audio', 0)}件 / "
+                f"社長音声・業務記録 {pending.get('ceo', 0)}件"
+            )
             return
 
         def progress(done: int, total: int, label: str) -> None:

--- a/scripts/eval_rag.py
+++ b/scripts/eval_rag.py
@@ -99,7 +99,9 @@ def main() -> None:
     parser.add_argument("query", nargs="?", help="質問文")
     parser.add_argument("--batch", help="1行1質問のテキストファイル")
     parser.add_argument("--from-logs", type=int, metavar="N", help="質問ログから直近N件を評価")
-    parser.add_argument("--sources", default="audio", help="audio / ceo / audio,ceo")
+    parser.add_argument(
+        "--sources", default="audio", help="audio / ceo / work をカンマ区切りで指定（例: audio,ceo,work）"
+    )
     args = parser.parse_args()
 
     rag = get_rag_service()

--- a/src/app.py
+++ b/src/app.py
@@ -9,7 +9,7 @@ from ui.tabs.upload_tab import run_upload_tab
 from ui.tabs.mic_tab import run_mic_tab
 from ui.tabs.results_tab import run_results_tab
 from ui.tabs.db_tab import run_db_tab
-from ui.tabs.rag_tab import run_ceo_rag_tab, run_rag_tab
+from ui.tabs.rag_tab import run_rag_tab
 from ui.tabs.ceo_tab import run_ceo_tab
 from ui.tabs.ceo_db_tab import run_ceo_db_tab
 # .envファイルを読み込む
@@ -79,15 +79,14 @@ st.session_state.settings = settings
 with st.sidebar:
     selected_model, use_structuring, debug_mode = build_sidebar(settings, log_dir, logger)
 
-tab1, tab2, tab_ceo, tab3, tab4, tab_ceo_db, tab5, tab_ceo_rag = st.tabs([
+tab1, tab2, tab_ceo, tab3, tab4, tab_ceo_db, tab5 = st.tabs([
     "📤 アップロード",
     "🎙️ マイク録音",
     "🎤 社長音声",
     "📊 処理結果",
     "🗄️ データベース",
     "📂 社長音声履歴",
-    "💬 現場録音に質問",
-    "💬 社長音声に質問",
+    "💬 録音データに質問",
 ])
 with tab1:
     run_upload_tab(selected_model, use_structuring, logger)
@@ -103,8 +102,6 @@ with tab_ceo_db:
     run_ceo_db_tab()
 with tab5:
     run_rag_tab()
-with tab_ceo_rag:
-    run_ceo_rag_tab()
 
 # フッター
 st.divider()

--- a/src/services/rag/context_builder.py
+++ b/src/services/rag/context_builder.py
@@ -19,6 +19,8 @@ from sqlalchemy.orm import Session
 _PARENT_TABLES = {
     "audio": ("audio_transcriptions", "audio_transcription_chunks"),
     "ceo": ("ceo_transcriptions", "ceo_transcription_chunks"),
+    # 業務記録(tags='業務記録')はceoと同じテーブルに保存される(検索時にタグで分岐済み)
+    "work": ("ceo_transcriptions", "ceo_transcription_chunks"),
 }
 
 

--- a/src/services/rag/prompt_builder.py
+++ b/src/services/rag/prompt_builder.py
@@ -3,23 +3,38 @@
 from __future__ import annotations
 
 from datetime import date
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Sequence, Union
 
 from services.rag.context_builder import ContextDoc
 from services.rag.date_utils import jst_today
 
-_SOURCE_LABELS = {"audio": "現場録音", "ceo": "社長音声"}
+_SOURCE_LABELS = {"audio": "現場録音", "ceo": "社長音声", "work": "業務記録"}
 
 
 _CORPUS_DESCRIPTIONS = {
     "audio": "現場の作業録音を文字起こしした「音声DB」",
     "ceo": "社長が録音した音声メモ・打ち合わせを文字起こしした「社長音声DB」",
+    "work": "業務内容を録音した「業務記録」",
 }
 
+# corpusはソースキー1つ(str)または複数(検索ソースの組)を受け取る
+Corpus = Union[str, Sequence[str]]
 
-def build_system_prompt(today: Optional[date] = None, corpus: str = "audio") -> str:
+
+def _corpus_description(corpus: Corpus) -> str:
+    """検索対象ソースの説明文。複数ソース検索時は「、」で並べる。"""
+    keys = [corpus] if isinstance(corpus, str) else list(corpus)
+    descs: List[str] = []
+    for key in keys:
+        desc = _CORPUS_DESCRIPTIONS.get(key)
+        if desc and desc not in descs:
+            descs.append(desc)
+    return "、".join(descs) or _CORPUS_DESCRIPTIONS["audio"]
+
+
+def build_system_prompt(today: Optional[date] = None, corpus: Corpus = "audio") -> str:
     today_str = (today or jst_today()).isoformat()
-    corpus_desc = _CORPUS_DESCRIPTIONS.get(corpus, _CORPUS_DESCRIPTIONS["audio"])
+    corpus_desc = _corpus_description(corpus)
     return (
         "あなたは射出成形工場の社内アシスタントです。"
         f"{corpus_desc}から検索した内容(コンテキスト)に基づいて質問に答えます。\n"
@@ -63,7 +78,7 @@ def build_chat_messages(
     docs: List[ContextDoc],
     chat_history: Optional[List[Dict]] = None,
     today: Optional[date] = None,
-    corpus: str = "audio",
+    corpus: Corpus = "audio",
     notes: Optional[List[str]] = None,
 ) -> List[Dict]:
     """回答生成用メッセージ列を組み立てる。

--- a/src/services/rag/search_service.py
+++ b/src/services/rag/search_service.py
@@ -19,19 +19,36 @@ from sqlalchemy.orm import Session
 from models import RAG_FTS_TABLES
 from services.rag.tokenizer import fts_query_any
 
-# ソース種別ごとのテーブル定義
+# デスクトップ版(stt-desktop)が ceo_transcriptions.tags に書き込む業務記録タグ。
+# Web版のCEO処理(ceo_processor.py)は tags='社長音声' を書き、既存行は tags NULL。
+WORK_RECORD_TAG = "業務記録"
+
+# ソース種別ごとのテーブル定義。
+# "ceo"と"work"は物理テーブル(ceo_transcriptions / ceo_transcription_chunks /
+# rag_fts_ceo)を共有し、検索時に親テーブルの tags でソースを分岐する("where")。
+# 索引(チャンク・FTS)はタグに関わらず全行が対象のままでよく、再構築は不要。
 _SOURCES: Dict[str, Dict[str, str]] = {
     "audio": {
         "chunks": "audio_transcription_chunks",
         "parent": "audio_transcriptions",
         "fts": RAG_FTS_TABLES["audio"],
         "title": "trans.file_path",
+        "where": "",
     },
     "ceo": {
         "chunks": "ceo_transcription_chunks",
         "parent": "ceo_transcriptions",
         "fts": RAG_FTS_TABLES["ceo"],
         "title": "COALESCE(NULLIF(trans.title, ''), trans.file_path)",
+        # 既存行(tags NULL)は従来通り社長音声として検索されることを保証する
+        "where": f" AND (trans.tags IS NULL OR trans.tags != '{WORK_RECORD_TAG}')",
+    },
+    "work": {
+        "chunks": "ceo_transcription_chunks",
+        "parent": "ceo_transcriptions",
+        "fts": RAG_FTS_TABLES["ceo"],
+        "title": "COALESCE(NULLIF(trans.title, ''), trans.file_path)",
+        "where": f" AND trans.tags = '{WORK_RECORD_TAG}'",
     },
 }
 
@@ -141,7 +158,7 @@ class SearchService:
                 f"vector_distance_cos(chunk.embedding, vector32(:qvec)) AS distance "
                 f"FROM {cfg['chunks']} AS chunk "
                 f"JOIN {cfg['parent']} AS trans ON trans.id = chunk.transcription_id "
-                f"WHERE chunk.embedding IS NOT NULL{_DATE_WHERE} "
+                f"WHERE chunk.embedding IS NOT NULL{cfg['where']}{_DATE_WHERE} "
                 f"ORDER BY distance ASC LIMIT :k"
             )
             params = {"qvec": qvec, "k": k, **filters.date_params()}
@@ -166,7 +183,7 @@ class SearchService:
                 f"FROM {fts} "
                 f"JOIN {cfg['chunks']} AS chunk ON chunk.id = {fts}.rowid "
                 f"JOIN {cfg['parent']} AS trans ON trans.id = chunk.transcription_id "
-                f"WHERE {fts} MATCH :q{_DATE_WHERE} "
+                f"WHERE {fts} MATCH :q{cfg['where']}{_DATE_WHERE} "
                 f"ORDER BY bm25 LIMIT :k"
             )
             params = {"q": match_query, "k": k, **filters.date_params()}
@@ -210,7 +227,7 @@ class SearchService:
                 text(
                     f"SELECT COUNT(*) AS n FROM {cfg['parent']} AS trans "
                     f"WHERE trans.transcript IS NOT NULL AND trans.transcript != ''"
-                    f"{_DATE_WHERE}"
+                    f"{cfg['where']}{_DATE_WHERE}"
                 ),
                 filters.date_params(),
             ).mappings().first()
@@ -237,7 +254,8 @@ class SearchService:
                 f"trans.created_at AS recorded_at, trans.duration_seconds AS duration, "
                 f"'{source}' AS source "
                 f"FROM {cfg['parent']} AS trans "
-                f"WHERE trans.transcript IS NOT NULL AND trans.transcript != ''{_DATE_WHERE} "
+                f"WHERE trans.transcript IS NOT NULL AND trans.transcript != ''"
+                f"{cfg['where']}{_DATE_WHERE} "
                 f"ORDER BY trans.recorded_date DESC, trans.id DESC LIMIT :max_recs"
             )
             params = {"max_recs": max_recordings, **filters.date_params()}
@@ -259,8 +277,10 @@ class SearchService:
         for source, cfg in _SOURCES.items():
             row = db.execute(
                 text(
-                    f"SELECT COUNT(*) AS n, MAX(recorded_date) AS latest "
-                    f"FROM {cfg['parent']} WHERE transcript IS NOT NULL AND transcript != ''"
+                    f"SELECT COUNT(*) AS n, MAX(trans.recorded_date) AS latest "
+                    f"FROM {cfg['parent']} AS trans "
+                    f"WHERE trans.transcript IS NOT NULL AND trans.transcript != ''"
+                    f"{cfg['where']}"
                 )
             ).mappings().first()
             stats[source] = {"count": row["n"] if row else 0, "latest": row["latest"] if row else None}
@@ -273,7 +293,11 @@ class SearchService:
         for source in sources:
             cfg = _SOURCES[source]
             row = db.execute(
-                text(f"SELECT MIN(recorded_date) AS lo, MAX(recorded_date) AS hi FROM {cfg['parent']}")
+                text(
+                    f"SELECT MIN(trans.recorded_date) AS lo, MAX(trans.recorded_date) AS hi "
+                    f"FROM {cfg['parent']} AS trans "
+                    f"WHERE trans.recorded_date IS NOT NULL{cfg['where']}"
+                )
             ).mappings().first()
             if row and row["lo"]:
                 lo = min(lo, row["lo"]) if lo else row["lo"]

--- a/src/services/rag_service.py
+++ b/src/services/rag_service.py
@@ -597,9 +597,8 @@ class RAGService:
         t1: float,
     ) -> Dict:
         """コンテキスト確定後の共通処理(プロンプト構築・ストリーム関数・メタ)。"""
-        corpus = "ceo" if tuple(plan.sources) == ("ceo",) else "audio"
         messages = build_chat_messages(
-            query, docs, chat_history, today, corpus=corpus, notes=notes or None
+            query, docs, chat_history, today, corpus=plan.sources, notes=notes or None
         )
         t2 = time.time()
 

--- a/src/ui/tabs/rag_tab.py
+++ b/src/ui/tabs/rag_tab.py
@@ -22,7 +22,7 @@ from services.rag_service import get_rag_service
 
 logger = logging.getLogger(__name__)
 
-_SOURCE_LABELS = {"audio": "現場録音", "ceo": "社長音声"}
+_SOURCE_LABELS = {"audio": "現場録音", "ceo": "社長音声", "work": "業務記録"}
 
 # 自動インデックスを黙って実行する上限(超える場合はボタンで明示実行)
 _AUTO_INDEX_LIMIT = 20
@@ -33,11 +33,14 @@ class _ChatProfile:
     """QAチャットの出口ごとの設定。現場録音と社長音声で会話・検索対象を分離する。"""
 
     key: str  # session_state・ウィジェットkey・chat_kindの識別子("audio"/"ceo")
-    sources: Tuple[str, ...]
+    sources: Tuple[str, ...]  # ソース選択の既定値(タブ内のpillsで変更可能)
     header: str
     placeholder: str
 
 
+# 既定では3ソース(現場録音・社長音声・業務記録)すべてがいずれかのタブの検索対象。
+# 業務記録はceo_transcriptionsにtags='業務記録'で保存されるため、社長音声タブの
+# 既定に含めることで従来の検索範囲(ceo_transcriptions全行)を維持する。
 _AUDIO_PROFILE = _ChatProfile(
     key="audio",
     sources=("audio",),
@@ -46,7 +49,7 @@ _AUDIO_PROFILE = _ChatProfile(
 )
 _CEO_PROFILE = _ChatProfile(
     key="ceo",
-    sources=("ceo",),
+    sources=("ceo", "work"),
     header="💬 社長音声に質問",
     placeholder="質問を入力（例: 最近の録音の内容をまとめて / 〇〇の件はどういう話だった？）",
 )
@@ -283,7 +286,7 @@ def _ensure_index(rag, profile: _ChatProfile, pending: Dict[str, int]) -> None:
     else:
         st.warning(
             f"⚠️ **{total}件の録音が検索インデックスに未登録です**"
-            f"（現場録音 {pending.get('audio', 0)}件 / 社長音声 {pending.get('ceo', 0)}件）。"
+            f"（現場録音 {pending.get('audio', 0)}件 / 社長音声・業務記録 {pending.get('ceo', 0)}件）。"
             "デスクトップ版で保存されたデータや、検索エンジンの更新"
             "（埋め込みモデル変更）による再作成分が該当します。"
             "インデックス化するまで、これらはキーワード・類似検索の対象になりません。"
@@ -331,12 +334,27 @@ def _run_chat(profile: _ChatProfile):
 
     # --- コーパス統計と索引状態 ---
     stats, pending = _corpus_snapshot()
-    src = profile.sources[0]
-    s = stats.get(src, {})
-    st.caption(
-        f"検索対象: {_SOURCE_LABELS[src]} **{s.get('count', 0)}件**"
-        f"（最新の録音日 {s.get('latest') or '—'}）"
+
+    # 検索ソース選択(既定はプロファイルごとの検索範囲。追加・除外できる)
+    selected = st.pills(
+        "検索ソース",
+        options=list(_SOURCE_LABELS),
+        format_func=_SOURCE_LABELS.get,
+        selection_mode="multi",
+        default=list(profile.sources),
+        key=f"rag_{profile.key}_sources",
+        label_visibility="collapsed",
     )
+    sel_sources = tuple(s for s in _SOURCE_LABELS if s in (selected or ()))
+    if sel_sources:
+        counts = " / ".join(
+            f"{_SOURCE_LABELS[s]} **{stats.get(s, {}).get('count', 0)}件**"
+            for s in sel_sources
+        )
+        latest = max(
+            (stats.get(s, {}).get("latest") or "" for s in sel_sources), default=""
+        )
+        st.caption(f"検索対象: {counts}（最新の録音日 {latest or '—'}）")
 
     _ensure_index(rag, profile, pending)
 
@@ -395,6 +413,10 @@ def _run_chat(profile: _ChatProfile):
                 with block.expander(f"参照した録音（{len(message['contexts'])}件）", expanded=False):
                     _render_context_docs(message["contexts"])
 
+    if not sel_sources:
+        st.info("検索ソースを1つ以上選択してください。")
+        return
+
     query = st.chat_input(profile.placeholder, key=f"rag_{profile.key}_chat_input")
     if not query:
         return
@@ -423,7 +445,7 @@ def _run_chat(profile: _ChatProfile):
             result = rag.answer_stream(
                 db,
                 query,
-                sources=profile.sources,
+                sources=sel_sources,
                 manual_date_range=manual_range,
                 chat_history=chat_history_for_rag,
                 previous_docs=previous_docs,

--- a/src/ui/tabs/rag_tab.py
+++ b/src/ui/tabs/rag_tab.py
@@ -1,19 +1,18 @@
 """音声DBへの質問(QAチャット)タブ。
 
-現場録音用(run_rag_tab)と社長音声用(run_ceo_rag_tab)で出口を分離している。
-検索エンジン(RAGService)は共通で、検索対象・会話履歴・プロンプトが
-プロファイル単位で切り替わる。
+現場録音・社長音声・業務記録の3ソースを1つのチャットで横断検索する。
+検索対象はソース選択pillsで自由に絞り込める(既定は全ソース)。
+検索エンジン(RAGService)は共通で、選択ソースが検索対象とプロンプトに反映される。
 """
 
 import json
 import logging
 import uuid
-from dataclasses import dataclass
 from datetime import date, datetime
 from typing import Dict, List, Optional, Tuple
 
 import streamlit as st
-from sqlalchemy import func, or_
+from sqlalchemy import func
 
 from models import RAGChatLog, USE_VECTOR, get_db
 from services.rag import highlight_date_in_query
@@ -24,52 +23,20 @@ logger = logging.getLogger(__name__)
 
 _SOURCE_LABELS = {"audio": "現場録音", "ceo": "社長音声", "work": "業務記録"}
 
+_HEADER = "💬 録音データに質問"
+_PLACEHOLDER = "質問を入力（例: 7/28の作業内容は？ / 〇〇の件はどういう話だった？）"
+
 # 自動インデックスを黙って実行する上限(超える場合はボタンで明示実行)
 _AUTO_INDEX_LIMIT = 20
-
-
-@dataclass(frozen=True)
-class _ChatProfile:
-    """QAチャットの出口ごとの設定。現場録音と社長音声で会話・検索対象を分離する。"""
-
-    key: str  # session_state・ウィジェットkey・chat_kindの識別子("audio"/"ceo")
-    sources: Tuple[str, ...]  # ソース選択の既定値(タブ内のpillsで変更可能)
-    header: str
-    placeholder: str
-
-
-# 既定では3ソース(現場録音・社長音声・業務記録)すべてがいずれかのタブの検索対象。
-# 業務記録はceo_transcriptionsにtags='業務記録'で保存されるため、社長音声タブの
-# 既定に含めることで従来の検索範囲(ceo_transcriptions全行)を維持する。
-_AUDIO_PROFILE = _ChatProfile(
-    key="audio",
-    sources=("audio",),
-    header="💬 現場録音に質問",
-    placeholder="質問を入力（例: 7/28の作業内容は？ / ボイドが出たとき過去はどう対処した？）",
-)
-_CEO_PROFILE = _ChatProfile(
-    key="ceo",
-    sources=("ceo", "work"),
-    header="💬 社長音声に質問",
-    placeholder="質問を入力（例: 最近の録音の内容をまとめて / 〇〇の件はどういう話だった？）",
-)
 
 
 # ----------------------------------------------------------------------
 # セッション管理
 # ----------------------------------------------------------------------
-def _get_or_create_session_id(profile: _ChatProfile) -> str:
-    key = f"rag_{profile.key}_session_id"
-    if key not in st.session_state:
-        st.session_state[key] = str(uuid.uuid4())
-    return st.session_state[key]
-
-
-def _kind_filter(profile: _ChatProfile):
-    """会話ログの出口別フィルタ。旧データ(chat_kind=NULL)は現場録音として扱う。"""
-    if profile.key == "ceo":
-        return RAGChatLog.chat_kind == "ceo"
-    return or_(RAGChatLog.chat_kind == "audio", RAGChatLog.chat_kind.is_(None))
+def _get_or_create_session_id() -> str:
+    if "rag_session_id" not in st.session_state:
+        st.session_state["rag_session_id"] = str(uuid.uuid4())
+    return st.session_state["rag_session_id"]
 
 
 def _load_session_history(session_id: str) -> List[Dict]:
@@ -96,7 +63,8 @@ def _load_session_history(session_id: str) -> List[Dict]:
         db.close()
 
 
-def _fetch_session_summaries(profile: _ChatProfile, limit: int = 15):
+def _fetch_session_summaries(limit: int = 15):
+    """過去の会話一覧。旧2タブ時代の会話(chat_kind別)もすべて表示する。"""
     db = next(get_db())
     try:
         base = (
@@ -106,7 +74,6 @@ def _fetch_session_summaries(profile: _ChatProfile, limit: int = 15):
                 func.max(RAGChatLog.created_at).label("last_updated"),
             )
             .filter(RAGChatLog.session_id.isnot(None))
-            .filter(_kind_filter(profile))
             .group_by(RAGChatLog.session_id)
             .subquery()
         )
@@ -130,9 +97,9 @@ def _fetch_session_summaries(profile: _ChatProfile, limit: int = 15):
         db.close()
 
 
-def _render_session_picker(profile: _ChatProfile, session_id: str) -> None:
+def _render_session_picker(session_id: str) -> None:
     with st.popover("🗂 過去の会話", use_container_width=True):
-        sessions = _fetch_session_summaries(profile)
+        sessions = _fetch_session_summaries()
         if not sessions:
             st.caption("保存された会話はありません。")
         for s in sessions:
@@ -143,11 +110,11 @@ def _render_session_picker(profile: _ChatProfile, session_id: str) -> None:
             updated = str(s.last_updated)[:10]  # YYYY-MM-DD
             if st.button(
                 f"{prefix}{updated}　{title}",
-                key=f"rag_{profile.key}_resume_{s.session_id}",
+                key=f"rag_resume_{s.session_id}",
                 use_container_width=True,
             ):
-                st.session_state[f"rag_{profile.key}_session_id"] = s.session_id
-                st.session_state[f"rag_{profile.key}_history"] = _load_session_history(s.session_id)
+                st.session_state["rag_session_id"] = s.session_id
+                st.session_state["rag_history"] = _load_session_history(s.session_id)
                 st.rerun()
 
 
@@ -231,7 +198,7 @@ def _handle_rag_error(error: Exception, context: str = ""):
 # ----------------------------------------------------------------------
 @st.cache_data(ttl=30, show_spinner=False)
 def _corpus_snapshot() -> Tuple[Dict, Dict]:
-    """コーパス統計と未索引件数。タブ2つ分の再照会を防ぐため30秒キャッシュする。"""
+    """コーパス統計と未索引件数。再描画のたびの再照会を防ぐため30秒キャッシュする。"""
     rag = get_rag_service()
     db = next(get_db())
     try:
@@ -240,7 +207,7 @@ def _corpus_snapshot() -> Tuple[Dict, Dict]:
         db.close()
 
 
-def _ensure_index(rag, profile: _ChatProfile, pending: Dict[str, int]) -> None:
+def _ensure_index(rag, pending: Dict[str, int]) -> None:
     """索引の差分を検出し、軽い処理は自動で、重い処理は明示実行で補完する。
 
     デスクトップ版などWeb以外の経路で保存されたデータもここで検索対象に取り込む。
@@ -294,7 +261,7 @@ def _ensure_index(rag, profile: _ChatProfile, pending: Dict[str, int]) -> None:
         if st.button(
             f"今すぐインデックス化する（約{max(1, total // 100)}〜{max(2, total // 50)}分）",
             type="primary",
-            key=f"rag_{profile.key}_reindex_btn",
+            key="rag_reindex_btn",
         ):
             _run_indexing()
 
@@ -303,17 +270,8 @@ def _ensure_index(rag, profile: _ChatProfile, pending: Dict[str, int]) -> None:
 # メイン
 # ----------------------------------------------------------------------
 def run_rag_tab():
-    """現場録音への質問タブ。"""
-    _run_chat(_AUDIO_PROFILE)
-
-
-def run_ceo_rag_tab():
-    """社長音声への質問タブ。"""
-    _run_chat(_CEO_PROFILE)
-
-
-def _run_chat(profile: _ChatProfile):
-    st.header(profile.header)
+    """録音データへの質問タブ。現場録音・社長音声・業務記録を横断検索する。"""
+    st.header(_HEADER)
 
     rag = get_rag_service()
 
@@ -327,22 +285,22 @@ def _run_chat(profile: _ChatProfile):
             st.warning("OPENAI_API_KEY が未設定のためQA検索を利用できません。")
         return
 
-    session_id = _get_or_create_session_id(profile)
-    hist_key = f"rag_{profile.key}_history"
+    session_id = _get_or_create_session_id()
+    hist_key = "rag_history"
     if hist_key not in st.session_state:
         st.session_state[hist_key] = []
 
     # --- コーパス統計と索引状態 ---
     stats, pending = _corpus_snapshot()
 
-    # 検索ソース選択(既定はプロファイルごとの検索範囲。追加・除外できる)
+    # 検索ソース選択(既定は全ソース。自由に絞り込める)
     selected = st.pills(
         "検索ソース",
         options=list(_SOURCE_LABELS),
         format_func=_SOURCE_LABELS.get,
         selection_mode="multi",
-        default=list(profile.sources),
-        key=f"rag_{profile.key}_sources",
+        default=list(_SOURCE_LABELS),
+        key="rag_sources",
         label_visibility="collapsed",
     )
     sel_sources = tuple(s for s in _SOURCE_LABELS if s in (selected or ()))
@@ -356,14 +314,14 @@ def _run_chat(profile: _ChatProfile):
         )
         st.caption(f"検索対象: {counts}（最新の録音日 {latest or '—'}）")
 
-    _ensure_index(rag, profile, pending)
+    _ensure_index(rag, pending)
 
     # --- 検索条件 ---
     ctrl_cols = st.columns([1.8, 1.1, 1.1])
     manual_range: Optional[Tuple[date, date]] = None
     with ctrl_cols[0]:
-        d_from = st.session_state.get(f"rag_{profile.key}_date_from")
-        d_to = st.session_state.get(f"rag_{profile.key}_date_to")
+        d_from = st.session_state.get("rag_date_from")
+        d_to = st.session_state.get("rag_date_to")
         period_label = (
             f"📅 {d_from} 〜 {d_to}" if (d_from and d_to) else "📅 期間: 自動判定"
         )
@@ -372,35 +330,35 @@ def _run_chat(profile: _ChatProfile):
             c1, c2 = st.columns(2)
             with c1:
                 d_from = st.date_input(
-                    "開始日", value=d_from, key=f"rag_{profile.key}_date_from_input", format="YYYY-MM-DD"
+                    "開始日", value=d_from, key="rag_date_from_input", format="YYYY-MM-DD"
                 )
             with c2:
                 d_to = st.date_input(
-                    "終了日", value=d_to, key=f"rag_{profile.key}_date_to_input", format="YYYY-MM-DD"
+                    "終了日", value=d_to, key="rag_date_to_input", format="YYYY-MM-DD"
                 )
             b1, b2 = st.columns(2)
             with b1:
-                if st.button("適用", use_container_width=True, key=f"rag_{profile.key}_date_apply"):
-                    st.session_state[f"rag_{profile.key}_date_from"] = d_from
-                    st.session_state[f"rag_{profile.key}_date_to"] = d_to
+                if st.button("適用", use_container_width=True, key="rag_date_apply"):
+                    st.session_state["rag_date_from"] = d_from
+                    st.session_state["rag_date_to"] = d_to
                     st.rerun()
             with b2:
-                if st.button("解除（自動に戻す）", use_container_width=True, key=f"rag_{profile.key}_date_clear"):
-                    st.session_state[f"rag_{profile.key}_date_from"] = None
-                    st.session_state[f"rag_{profile.key}_date_to"] = None
+                if st.button("解除（自動に戻す）", use_container_width=True, key="rag_date_clear"):
+                    st.session_state["rag_date_from"] = None
+                    st.session_state["rag_date_to"] = None
                     st.rerun()
-        if st.session_state.get(f"rag_{profile.key}_date_from") and st.session_state.get(f"rag_{profile.key}_date_to"):
+        if st.session_state.get("rag_date_from") and st.session_state.get("rag_date_to"):
             manual_range = (
-                st.session_state[f"rag_{profile.key}_date_from"],
-                st.session_state[f"rag_{profile.key}_date_to"],
+                st.session_state["rag_date_from"],
+                st.session_state["rag_date_to"],
             )
     with ctrl_cols[1]:
-        if st.button("✨ 新規会話", use_container_width=True, key=f"rag_{profile.key}_new_session"):
-            st.session_state[f"rag_{profile.key}_session_id"] = str(uuid.uuid4())
+        if st.button("✨ 新規会話", use_container_width=True, key="rag_new_session"):
+            st.session_state["rag_session_id"] = str(uuid.uuid4())
             st.session_state[hist_key] = []
             st.rerun()
     with ctrl_cols[2]:
-        _render_session_picker(profile, session_id)
+        _render_session_picker(session_id)
 
     # --- 会話履歴表示 ---
     for message in st.session_state[hist_key]:
@@ -417,7 +375,7 @@ def _run_chat(profile: _ChatProfile):
         st.info("検索ソースを1つ以上選択してください。")
         return
 
-    query = st.chat_input(profile.placeholder, key=f"rag_{profile.key}_chat_input")
+    query = st.chat_input(_PLACEHOLDER, key="rag_chat_input")
     if not query:
         return
 
@@ -500,7 +458,11 @@ def _run_chat(profile: _ChatProfile):
     try:
         log = RAGChatLog(
             session_id=session_id,
-            chat_kind=profile.key,
+            # タブ統合後もカラムの値域("audio"/"ceo")は変えず、デスクトップ版
+            # (stt-desktop commands/rag.rs)と同じ規則で記録する:
+            # 現場録音を含む検索=audio / 含まない=ceo。
+            # 回答ごとの参照ソースはcontexts[].sourceに残る。
+            chat_kind="audio" if "audio" in sel_sources else "ceo",
             user_text=query,
             answer_text=full_text,
             contexts=contexts_json,

--- a/tests/test_rag_work_source.py
+++ b/tests/test_rag_work_source.py
@@ -1,0 +1,250 @@
+"""workソース(業務記録)の検索絞り込みテスト。
+
+業務記録はceo_transcriptionsにtags='業務記録'で保存される(デスクトップ版PR #17)。
+検索時のみタグで分岐し、既存行(tags NULL)や他タグの行は従来通り
+社長音声(ceo)として検索されることを保証する。
+"""
+
+import os
+import sys
+from datetime import date
+from pathlib import Path
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pytest  # noqa: E402
+from sqlalchemy import create_engine, event, text  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+
+from services.rag.context_builder import _PARENT_TABLES, build_context_docs  # noqa: E402
+from services.rag.prompt_builder import (  # noqa: E402
+    _SOURCE_LABELS,
+    build_system_prompt,
+)
+from services.rag.search_service import (  # noqa: E402
+    SearchFilters,
+    SearchService,
+    VALID_SOURCES,
+    WORK_RECORD_TAG,
+)
+from services.rag.tokenizer import fts_query_any, to_fts_text  # noqa: E402
+
+# (id, title, tags, recorded_date, transcript)
+_CEO_ROWS = [
+    (1, "既存メモ", None, "2026-08-01", "既存データ。在庫の確認をした。"),
+    (2, "社長メモ", "社長音声", "2026-08-02", "社長音声。在庫の相談をした。"),
+    (3, "業務記録1", WORK_RECORD_TAG, "2026-08-03", "業務記録。在庫の棚卸しをした。"),
+    (4, "会議メモ", "会議", "2026-08-04", "他タグ。在庫の報告をした。"),
+    (5, "空タグ", "", "2026-08-05", "空タグ。在庫の連絡をした。"),
+]
+
+
+@pytest.fixture()
+def db():
+    engine = create_engine("sqlite://")
+
+    @event.listens_for(engine, "connect")
+    def _register_vector_fns(dbapi_conn, _record):
+        # libsql固有のベクトル関数をテスト用に代替する
+        # (embedding列に格納した数値文字列をそのまま距離として返す)
+        dbapi_conn.create_function("vector32", 1, lambda s: s)
+        dbapi_conn.create_function(
+            "vector_distance_cos", 2, lambda emb, _q: float(emb)
+        )
+
+    with engine.begin() as c:
+        c.execute(text(
+            "CREATE TABLE audio_transcriptions ("
+            "id INTEGER PRIMARY KEY, file_path TEXT, transcript TEXT, tags TEXT, "
+            "recorded_date TEXT, created_at TEXT, duration_seconds REAL)"
+        ))
+        c.execute(text(
+            "CREATE TABLE ceo_transcriptions ("
+            "id INTEGER PRIMARY KEY, title TEXT, file_path TEXT, transcript TEXT, "
+            "tags TEXT, recorded_date TEXT, created_at TEXT, duration_seconds REAL)"
+        ))
+        for tbl in ("audio_transcription_chunks", "ceo_transcription_chunks"):
+            c.execute(text(
+                f"CREATE TABLE {tbl} ("
+                "id INTEGER PRIMARY KEY, transcription_id INTEGER, chunk_index INTEGER, "
+                "chunk_text TEXT, embedding TEXT, start_sec REAL, end_sec REAL, "
+                "time_basis TEXT)"
+            ))
+        c.execute(text("CREATE VIRTUAL TABLE rag_fts_audio USING fts5(tokens)"))
+        c.execute(text("CREATE VIRTUAL TABLE rag_fts_ceo USING fts5(tokens)"))
+
+        c.execute(
+            text(
+                "INSERT INTO audio_transcriptions VALUES "
+                "(1, 'field.mp3', '現場録音。在庫の話。', NULL, '2026-08-01', NULL, 10.0)"
+            )
+        )
+        c.execute(text(
+            "INSERT INTO audio_transcription_chunks VALUES "
+            "(1, 1, 0, '現場録音。在庫の話。', '0.1', NULL, NULL, NULL)"
+        ))
+        c.execute(
+            text("INSERT INTO rag_fts_audio(rowid, tokens) VALUES (1, :tokens)"),
+            {"tokens": to_fts_text("現場録音。在庫の話。")},
+        )
+
+        for tid, title, tags, rec_date, transcript in _CEO_ROWS:
+            c.execute(
+                text(
+                    "INSERT INTO ceo_transcriptions VALUES "
+                    "(:id, :title, NULL, :transcript, :tags, :rec_date, NULL, 10.0)"
+                ),
+                {"id": tid, "title": title, "tags": tags,
+                 "rec_date": rec_date, "transcript": transcript},
+            )
+            chunk_id = tid * 10
+            c.execute(
+                text(
+                    "INSERT INTO ceo_transcription_chunks VALUES "
+                    "(:cid, :tid, 0, :text, :emb, NULL, NULL, NULL)"
+                ),
+                {"cid": chunk_id, "tid": tid, "text": transcript,
+                 "emb": str(0.1 * tid)},
+            )
+            c.execute(
+                text("INSERT INTO rag_fts_ceo(rowid, tokens) VALUES (:cid, :tokens)"),
+                {"cid": chunk_id, "tokens": to_fts_text(transcript)},
+            )
+
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    yield session
+    session.close()
+
+
+def _tids(rows):
+    return sorted(int(r["transcription_id"]) for r in rows)
+
+
+class TestWorkSourceSplit:
+    """work = tags='業務記録' のみ / ceo = それ以外(NULL・他タグ・空文字含む)。"""
+
+    def test_valid_sources(self):
+        assert VALID_SOURCES == ("audio", "ceo", "work")
+
+    def test_browse_recent_work_only_hits_work_tag(self, db):
+        rows = SearchService().browse_recent(
+            db, SearchFilters(sources=("work",)), max_recordings=10
+        )
+        assert _tids(rows) == [3]
+        assert rows[0]["source"] == "work"
+        assert rows[0]["tags"] == WORK_RECORD_TAG
+
+    def test_browse_recent_ceo_excludes_work_and_keeps_null(self, db):
+        rows = SearchService().browse_recent(
+            db, SearchFilters(sources=("ceo",)), max_recordings=10
+        )
+        # NULL(既存データ)・社長音声・他タグ・空文字はceo扱いのまま
+        assert _tids(rows) == [1, 2, 4, 5]
+        assert all(r["source"] == "ceo" for r in rows)
+
+    def test_count_recordings_split(self, db):
+        svc = SearchService()
+        assert svc.count_recordings(db, SearchFilters(sources=("work",))) == 1
+        assert svc.count_recordings(db, SearchFilters(sources=("ceo",))) == 4
+        assert svc.count_recordings(db, SearchFilters(sources=("ceo", "work"))) == 5
+
+    def test_keyword_search_split(self, db):
+        svc = SearchService()
+        q = fts_query_any("在庫")
+        work = svc.keyword_search(db, q, SearchFilters(sources=("work",)), k=10)
+        ceo = svc.keyword_search(db, q, SearchFilters(sources=("ceo",)), k=10)
+        assert _tids(work) == [3]
+        assert _tids(ceo) == [1, 2, 4, 5]
+
+    def test_vector_search_split(self, db):
+        svc = SearchService()
+        qvec = [0.0] * 4
+        work = svc.vector_search(db, qvec, SearchFilters(sources=("work",)), k=10)
+        ceo = svc.vector_search(db, qvec, SearchFilters(sources=("ceo",)), k=10)
+        assert _tids(work) == [3]
+        assert _tids(ceo) == [1, 2, 4, 5]
+
+    def test_three_source_union_covers_all_rows(self, db):
+        svc = SearchService()
+        q = fts_query_any("在庫")
+        rows = svc.keyword_search(
+            db, q, SearchFilters(sources=("audio", "ceo", "work")), k=10
+        )
+        assert {(r["source"], int(r["transcription_id"])) for r in rows} == {
+            ("audio", 1), ("ceo", 1), ("ceo", 2), ("work", 3), ("ceo", 4), ("ceo", 5),
+        }
+
+    def test_date_filter_applies_to_work(self, db):
+        svc = SearchService()
+        in_range = SearchFilters(
+            date_from=date(2026, 8, 3), date_to=date(2026, 8, 3), sources=("work",)
+        )
+        out_of_range = SearchFilters(
+            date_from=date(2026, 8, 4), date_to=date(2026, 8, 5), sources=("work",)
+        )
+        assert _tids(svc.browse_recent(db, in_range, 10)) == [3]
+        assert svc.browse_recent(db, out_of_range, 10) == []
+
+    def test_corpus_stats_split(self, db):
+        stats = SearchService().corpus_stats(db)
+        assert stats["work"]["count"] == 1
+        assert stats["ceo"]["count"] == 4
+        assert stats["audio"]["count"] == 1
+        assert stats["work"]["latest"] == "2026-08-03"
+        assert stats["ceo"]["latest"] == "2026-08-05"
+
+    def test_available_date_range_split(self, db):
+        svc = SearchService()
+        assert svc.available_date_range(db, ("work",)) == ("2026-08-03", "2026-08-03")
+        assert svc.available_date_range(db, ("ceo",)) == ("2026-08-01", "2026-08-05")
+
+
+class TestContextBuilderWork:
+    def test_parent_tables_share_ceo_tables(self):
+        assert _PARENT_TABLES["work"] == ("ceo_transcriptions", "ceo_transcription_chunks")
+
+    def test_build_context_docs_for_work_hit(self, db):
+        hits = [{
+            "source": "work",
+            "transcription_id": 3,
+            "title": "業務記録1",
+            "recorded_date": "2026-08-03",
+            "tags": WORK_RECORD_TAG,
+            "score": 1.0,
+            "chunk_id": 30,
+            "chunk_index": 0,
+            "chunk_text": "業務記録。在庫の棚卸しをした。",
+        }]
+        docs = build_context_docs(db, hits, max_docs=5, max_chars=10000)
+        assert len(docs) == 1
+        assert docs[0].source == "work"
+        assert "棚卸し" in docs[0].text
+
+
+class TestPromptBuilderWork:
+    def test_source_label(self):
+        assert _SOURCE_LABELS["work"] == "業務記録"
+
+    def test_system_prompt_work_only(self):
+        prompt = build_system_prompt(today=date(2026, 8, 11), corpus=("work",))
+        assert "業務記録" in prompt
+        assert "社長音声DB" not in prompt
+
+    def test_system_prompt_multi_source_lists_all(self):
+        prompt = build_system_prompt(
+            today=date(2026, 8, 11), corpus=("audio", "ceo", "work")
+        )
+        assert "音声DB" in prompt
+        assert "社長音声DB" in prompt
+        assert "業務記録" in prompt
+
+    def test_system_prompt_accepts_plain_string(self):
+        # 既存の呼び出し形式(corpus="ceo")の後方互換
+        prompt = build_system_prompt(today=date(2026, 8, 11), corpus="ceo")
+        assert "社長音声DB" in prompt
+
+    def test_system_prompt_unknown_falls_back_to_audio(self):
+        prompt = build_system_prompt(today=date(2026, 8, 11), corpus=())
+        assert "音声DB" in prompt


### PR DESCRIPTION
## 概要

課題199「新タブ『業務記録』の追加とタグによるDB区別」のWeb側対応です。

デスクトップ版PR（stt-desktop#17、マージ前）により、今後 `ceo_transcriptions` に `tags='業務記録'`（業務記録タブのマイク録音）と `tags='社長音声'`（社長音声タブ）が書き込まれます。これに合わせ、RAGチャットの検索ソースを `audio`（現場録音）/ `ceo`（社長音声）/ `work`（業務記録）の3値に拡張します。

さらに、ソース選択pillsの導入でQAチャットのタブ分離（検索対象の分離）が機能重複になったため、**「現場録音に質問」「社長音声に質問」の2タブを「💬 録音データに質問」1タブに統合**しました（デスクトップ版 stt-desktop#19 の「1タブ+pills、既定3ソースon」と同構成）。

> **Note**
> 本PRは課題198のPR #13（`feature/issue-198-utterance-timestamps`）の上に積んだスタックPRです。**PR #13のマージ後にマージしてください**（マージ後にbaseをmainへ変更）。

## ソースの定義

| ソース | 対象 |
|---|---|
| `audio` | `audio_transcriptions` 全行（従来通り） |
| `ceo` | `ceo_transcriptions` のうち `tags` が `'業務記録'` 以外（**NULL含む**） |
| `work` | `ceo_transcriptions` のうち `tags = '業務記録'` |

既存行（tags NULL）が今まで通り「社長音声」として検索されることをテストで保証しています。デスクトップ版の一覧絞り込み（`tag` / `excludeTag`）と同じ分割です。

## 実装方式: 検索時のJOIN条件で分岐（索引の再構築なし）

チャンクテーブル（`ceo_transcription_chunks`）とFTS索引（`rag_fts_ceo`）は `ceo` / `work` で共有したまま、検索SQLの親テーブルJOINに `tags` 条件を付与して分岐します（`search_service.py` の `_SOURCES[...]["where"]`）。

- チャンクへのカラム追加が不要で、**既存索引データの再構築が発生しない**
- 索引・再同期（reconcile / find_unindexed / sync_fts）は物理テーブル単位（audio/ceo）のままで変更なし。ソース判定は検索時のみ
- 適用経路: `vector_search` / `keyword_search` / `count_recordings` / `browse_recent` / `corpus_stats` / `available_date_range` のすべて

## UI: 1タブ+ソース選択pillsに統合

QAチャットを「💬 録音データに質問」の1タブに統合し、検索対象はソース選択pills（`st.pills`、複数選択）で切り替えます。

- **既定は3ソースすべてon**。自由にon/offでき、全解除時は入力を無効化（案内表示）
- キャプションに選択中ソースごとの件数を表示
- `_ChatProfile`（プロファイル分離）を廃止し、会話履歴・セッション状態・ウィジェットkeyを1本化。フォローアップ（前回参照録音の再利用）・履歴の受け渡しは従来のまま動作
- ヘッダ・プレースホルダも統合（例文は現場系・社長音声系から1つずつ）
- 「過去の会話」一覧は`chat_kind`によるフィルタを撤去し、旧2タブ時代の会話（audio/ceo/NULL）をすべて表示・再開可能

## 会話ログ（`rag_chat_logs.chat_kind`）の扱い

カラムの値域（`"audio"` / `"ceo"` / NULL=旧データ）は変えず、デスクトップ版（stt-desktop#19 `commands/rag.rs`）と同じ規則で記録します: **現場録音を含む検索="audio" / 含まない="ceo"**。回答ごとの実際の参照ソースは従来通り `contexts[].source` に残るため、選択ソースの分析はそちらで可能です（スキーマ変更なし・後方互換）。

## その他の変更

- プロンプト: `work` のラベル「業務記録」とコーパス説明「業務内容を録音した「業務記録」」を追加。複数ソース検索時は説明を並記（`corpus` はソースの組を受け取るよう拡張、既存のstr指定も後方互換）
- コンテキストヘッダ・出典カードのソース表示も3ソース対応（既存の `_SOURCE_LABELS` 参照箇所がそのまま機能）
- `scripts/eval_rag.py --sources` にworkを案内、`scripts/backfill_rag.py` の未インデックス表示ラベルを「社長音声・業務記録」に修正
- CLAUDE.mdのQAチャット構成の記述を1タブ+pillsに更新

## テスト

- 新規 `tests/test_rag_work_source.py`（17件）: タグ分岐（`tags='業務記録'` のみwork、NULL・他タグ・空文字はceo）、3ソースunion、日付フィルタ併用、`corpus_stats` / `available_date_range` の分割、プロンプトの3ソース対応・後方互換
- `uv run python -m pytest tests/`: **186件全通過**（ベース169件 + 新規17件、デグレなし）
- Streamlit AppTestで統合後の動作を確認済み: pills既定値（3ソースon）・件数キャプション・`chat_kind`記録規則（audio含む=audio / 含まない=ceo）・フォローアップ（`previous_docs` / `chat_history` の受け渡し）・全解除時の入力無効化

## 動作確認の観点

1. 既定（3ソースon）で現場録音・社長音声・業務記録が横断検索できること
2. 「業務記録」のみ選択 → `tags='業務記録'` の録音だけが参照されること
3. 既存レコード（タグなし）が「社長音声」ソースとして検索・表示されること
4. 出典カード・参照録音のソースバッジに「業務記録」が表示されること
5. 統合前の会話（旧2タブそれぞれの履歴）が「過去の会話」から再開できること
